### PR TITLE
Fix stack overflow exception when using memberservice in member event observer

### DIFF
--- a/VirtoCommerce.CustomerModule.Data/Services/CommerceMembersServiceImpl.cs
+++ b/VirtoCommerce.CustomerModule.Data/Services/CommerceMembersServiceImpl.cs
@@ -19,8 +19,10 @@ namespace VirtoCommerce.CustomerModule.Data.Services
     public class CommerceMembersServiceImpl : MemberServiceBase
     {
         private readonly ISecurityService _securityService;
-        public CommerceMembersServiceImpl(Func<ICustomerRepository> repositoryFactory, IDynamicPropertyService dynamicPropertyService, ICommerceService commerceService, ISecurityService securityService, IEventPublisher<MemberChangingEvent> memberChangingEventPublisher, IEventPublisher<MemberChangedEvent> memberChangedEventPublisher)
-            : base(repositoryFactory, dynamicPropertyService, commerceService, memberChangingEventPublisher, memberChangedEventPublisher)
+        public CommerceMembersServiceImpl(Func<ICustomerRepository> repositoryFactory, IDynamicPropertyService dynamicPropertyService, 
+            ICommerceService commerceService, ISecurityService securityService, Func<IEventPublisher<MemberChangingEvent>> memberChangingEventPublisherFunc, 
+            Func<IEventPublisher<MemberChangedEvent>> memberChangedEventPublisherFunc)
+            : base(repositoryFactory, dynamicPropertyService, commerceService, memberChangingEventPublisherFunc, memberChangedEventPublisherFunc)
         {
             _securityService = securityService;
         }

--- a/VirtoCommerce.CustomerModule.Data/Services/MemberServiceBase.cs
+++ b/VirtoCommerce.CustomerModule.Data/Services/MemberServiceBase.cs
@@ -23,19 +23,21 @@ namespace VirtoCommerce.CustomerModule.Data.Services
     public abstract class MemberServiceBase : ServiceBase, IMemberService, IMemberSearchService
     {
         protected MemberServiceBase(Func<IMemberRepository> repositoryFactory, IDynamicPropertyService dynamicPropertyService, ICommerceService commerceService,
-                                  IEventPublisher<MemberChangingEvent> memberChangingEventPublisher, IEventPublisher<MemberChangedEvent> memberChangedEventPublisher)
+                                  Func<IEventPublisher<MemberChangingEvent>> memberChangingEventPublisherFunc, Func<IEventPublisher<MemberChangedEvent>> memberChangedEventPublisherFunc)
         {
             RepositoryFactory = repositoryFactory;
             DynamicPropertyService = dynamicPropertyService;
-            MemberChangingEventPublisher = memberChangingEventPublisher;
-            MemberChangedEventPublisher = memberChangedEventPublisher;
+            MemberChangingEventPublisherFunc = memberChangingEventPublisherFunc;
+            MemberChangedEventPublisherFunc = memberChangedEventPublisherFunc;
             CommerceService = commerceService;
         }
 
         protected Func<IMemberRepository> RepositoryFactory { get; }
         protected IDynamicPropertyService DynamicPropertyService { get; }
-        protected IEventPublisher<MemberChangingEvent> MemberChangingEventPublisher { get; }
-        protected IEventPublisher<MemberChangedEvent> MemberChangedEventPublisher { get; }
+        protected Func<IEventPublisher<MemberChangingEvent>> MemberChangingEventPublisherFunc { get; }
+        protected IEventPublisher<MemberChangingEvent> MemberChangingEventPublisher => MemberChangingEventPublisherFunc();
+        protected Func<IEventPublisher<MemberChangedEvent>> MemberChangedEventPublisherFunc { get; }
+        protected IEventPublisher<MemberChangedEvent> MemberChangedEventPublisher => MemberChangedEventPublisherFunc();
         protected ICommerceService CommerceService { get; set; }
 
 


### PR DESCRIPTION
I need to use the IMemberService from an IObserver<MemberChangingEvent>. This causes stackoverflow exceptions because the IMemberService has IEventPublishing<MemberChangingEvent> which of course has all of the IObserver<MemberChangingEvent>.  By using a func for the publishers, this is no longer an issue.