### PR TITLE
Removed reference to PlatformAccount table

### DIFF
--- a/VirtoCommerce.CustomerModule.Data/Migrations/201602191500249_Refactoring.cs
+++ b/VirtoCommerce.CustomerModule.Data/Migrations/201602191500249_Refactoring.cs
@@ -2,7 +2,7 @@ namespace VirtoCommerce.CustomerModule.Data.Migrations
 {
     using System;
     using System.Data.Entity.Migrations;
-    
+
     public partial class Refactoring : DbMigration
     {
         public override void Up()
@@ -15,10 +15,8 @@ namespace VirtoCommerce.CustomerModule.Data.Migrations
             DropColumn("dbo.MemberRelation", "Discriminator");
             DropColumn("dbo.Note", "Discriminator");
             DropColumn("dbo.Phone", "Discriminator");
-
-            Sql(@"UPDATE PlatformAccount SET PlatformAccount.MemberId = M.Id FROM  Member AS M WHERE PlatformAccount.MemberId IS NULL AND PlatformAccount.Id = M.Id");
         }
-        
+
         public override void Down()
         {
             AddColumn("dbo.Phone", "Discriminator", c => c.String(maxLength: 128));


### PR DESCRIPTION
Existing reference to the PlatformAccount table doesn't allow to use a separate database for the customer module.