### PR TITLE
VP-1390: Fix authorization for member collections

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Web/Authorization/CustomerAuthorizationHandler.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Authorization/CustomerAuthorizationHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -74,12 +73,10 @@ namespace VirtoCommerce.CustomerModule.Web.Authorization
                     criteria.ObjectIds = currentContact.AssociatedOrganizations;
                     context.Succeed(requirement);
                     break;
-                case List<Member> members:
+                case Member[] members:
                     {
-                        members.RemoveAll(x => !(((x is Organization org) && IsOrganizationInAssociatedOrganizations(currentContact, org))
-                            || ((x is Contact contact) && IsContactHasAssociatedOrganization(currentContact, contact))));
-
-                        if (members.Any())
+                        if (members.All(x => (((x is Organization org) && IsOrganizationInAssociatedOrganizations(currentContact, org))
+                            || ((x is Contact contact) && IsContactHasAssociatedOrganization(currentContact, contact)))))
                         {
                             context.Succeed(requirement);
                         }

--- a/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
@@ -344,7 +344,9 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
             {
                 return Unauthorized();
             }
-            return await BulkUpdateOrganizations(organizations);
+
+            await _memberService.SaveChangesAsync(organizations);
+            return NoContent(); // TODO: write here return Ok(organizations) when updating storefront AutoRest proxies to VC v3            
         }
 
         /// <summary>
@@ -676,12 +678,8 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
                     organizationsIds = employee.Organizations?.ToList() ?? organizationsIds;
                 }
             }
-            var organizations = await GetOrganizationsByIds(organizationsIds.ToArray());
-            if (!(await AuthorizeAsync(organizations, ModuleConstants.Security.Permissions.Read)).Succeeded)
-            {
-                return Unauthorized();
-            }
-            return organizations;
+
+            return await GetOrganizationsByIds(organizationsIds.ToArray());
         }
         #endregion
 

--- a/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
@@ -104,7 +104,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         {
             //pass member types name for better performance
             var retVal = await _memberService.GetByIdsAsync(ids, responseGroup, memberTypes);
-            if (!(await AuthorizeAsync(retVal.ToList(), ModuleConstants.Security.Permissions.Read)).Succeeded)
+            if (!(await AuthorizeAsync(retVal, ModuleConstants.Security.Permissions.Read)).Succeeded)
             {
                 return Unauthorized();
             }
@@ -147,7 +147,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         [ProducesResponseType((int)HttpStatusCode.Unauthorized)]
         public async Task<ActionResult<Member[]>> BulkCreateMembers([FromBody] Member[] members)
         {
-            if (!(await AuthorizeAsync(members.ToList(), ModuleConstants.Security.Permissions.Create)).Succeeded)
+            if (!(await AuthorizeAsync(members, ModuleConstants.Security.Permissions.Create)).Succeeded)
             {
                 return Unauthorized();
             }
@@ -186,7 +186,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
         public async Task<ActionResult> BulkUpdateMembers([FromBody] Member[] members)
         {
-            if (!(await AuthorizeAsync(members.ToList(), ModuleConstants.Security.Permissions.Update)).Succeeded)
+            if (!(await AuthorizeAsync(members, ModuleConstants.Security.Permissions.Update)).Succeeded)
             {
                 return Unauthorized();
             }


### PR DESCRIPTION
- Using member lists instead of arrays in all places;
- Using filtered results for saving, not initial unfiltered arrays;
- Remove redundant auth check for GetMemberOrganizations;

In general, need to decide if we want to use lists in authorization checks. Using arrays with array copying ref method seems less painful approach now. Similar changes should be done in extension modules, which could be unexpected for the platform users.