### PR TITLE
HDOT-1482 Fix indexed search considering only the first condition from search keyword

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Search/MemberSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Search/MemberSearchRequestBuilder.cs
@@ -34,8 +34,7 @@ namespace VirtoCommerce.CustomerModule.Data.Search
                 {
                     SearchKeywords = categorySearchCriteria.Keyword,
                     SearchFields = new[] { IndexDocumentExtensions.SearchableFieldName },
-                    //TODO will check
-                    Filter = filters.FirstOrDefault(),
+                    Filter = filters.And(),
                     Sorting = GetSorting(categorySearchCriteria),
                     Skip = criteria.Skip,
                     Take = criteria.Take,


### PR DESCRIPTION
### Problem
Currently, `VirtoCommerce.CustomerModule` does not allow to do an indexed search using conditions with 2 or more terms - it considers only the first term and ignores all of the following terms. For example, if you do a search for `membertype:Contact name:John`, the search will return all contacts regardless of their names.

### Solution
If the search keyword lists more than one search condition, all of these conditions should be considered when filtering the search results.

### Proposed of changes
I've just reverted a stub left by some VC3 developer and restored a [behavior from VC2](https://github.com/VirtoCommerce/vc-module-customer/blob/support/2.x-dev/VirtoCommerce.CustomerModule.Data/Search/MemberSearchRequestBuilder.cs#L36). Now all of the search filters parsed from the search keyword should be combined with an `AND` condition, and the search will return only the entries matching all of entered search conditions.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
