### PR TITLE
VP-2368: Can't delete contact in admin

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Migrations/20000000000000_UpdateCustomerV2.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Migrations/20000000000000_UpdateCustomerV2.cs
@@ -10,12 +10,12 @@ namespace VirtoCommerce.CustomerModule.Data.Migrations
                 IF (EXISTS (SELECT * FROM __MigrationHistory WHERE ContextKey = 'VirtoCommerce.CustomerModule.Data.Migrations.Configuration'))
                     BEGIN
 
-	                    BEGIN
-		                    INSERT INTO [__EFMigrationsHistory] ([MigrationId],[ProductVersion]) VALUES ('20190510074541_InitialCustomer', '2.2.3-servicing-35854')
-	                    END
-	                    
-	                    BEGIN
-		                    ALTER TABLE [Member] ADD [Discriminator] nvarchar(128) NOT NULL DEFAULT ('Member')
+                        BEGIN
+                            INSERT INTO [__EFMigrationsHistory] ([MigrationId],[ProductVersion]) VALUES ('20190510074541_InitialCustomer', '2.2.3-servicing-35854')
+                        END
+                        
+                        BEGIN
+                            ALTER TABLE [Member] ADD [Discriminator] nvarchar(128) NOT NULL DEFAULT ('Member')
                             ALTER TABLE [Member] ADD [FirstName] nvarchar(128) NULL
                             ALTER TABLE [Member] ADD [MiddleName] nvarchar(128) NULL
                             ALTER TABLE [Member] ADD [LastName] nvarchar(128) NULL
@@ -36,26 +36,30 @@ namespace VirtoCommerce.CustomerModule.Data.Migrations
                             ALTER TABLE [Member] ADD [SiteUrl] nvarchar(2048) NULL
                             ALTER TABLE [Member] ADD [LogoUrl] nvarchar(2048) NULL
                             ALTER TABLE [Member] ADD [GroupName] nvarchar(64) NULL
-	                    END
+                        END
 
-	                    BEGIN
-		                    EXEC (N'UPDATE Member SET Discriminator = CONCAT(MemberType, ''Entity'') , FirstName = c.FirstName,
+                        BEGIN
+                            EXEC (N'UPDATE Member SET Discriminator = CONCAT(MemberType, ''Entity'') , FirstName = c.FirstName,
                                     MiddleName = c.MiddleName, LastName = c.LastName, FullName = c.FullName, TimeZone = c.TimeZone,
-	                                DefaultLanguage = c.DefaultLanguage, BirthDate = c.BirthDate, TaxpayerId = c.TaxpayerId,
+                                    DefaultLanguage = c.DefaultLanguage, BirthDate = c.BirthDate, TaxpayerId = c.TaxpayerId,
                                     PreferredDelivery = c.PreferredDelivery, PreferredCommunication = c.PreferredCommunication, 
-	                                PhotoUrl = c.PhotoUrl, Salutation = c.Salutation
+                                    PhotoUrl = c.PhotoUrl, Salutation = c.Salutation
                                     FROM Member m INNER JOIN Contact c ON c.Id = m.Id')
-		                    EXEC (N'UPDATE Member SET Discriminator = CONCAT(MemberType, ''Entity'') , [Type] = o.OrgType,
+                            EXEC (N'UPDATE Member SET Discriminator = CONCAT(MemberType, ''Entity'') , [Type] = o.OrgType,
                                     [Description] = o.Description, BusinessCategory = o.BusinessCategory, OwnerId = o.OwnerId
                                     FROM Member m INNER JOIN Organization o ON o.Id = m.Id')
-		                    EXEC (N'UPDATE Member SET Discriminator = CONCAT(MemberType, ''Entity'') , [Description] = v.Description,
+                            EXEC (N'UPDATE Member SET Discriminator = CONCAT(MemberType, ''Entity'') , [Description] = v.Description,
                                     SiteUrl = v.SiteUrl, LogoUrl = v.LogoUrl, GroupName = v.GroupName
                                     FROM Member m INNER JOIN Vendor v ON v.Id = m.Id')
                             EXEC (N'UPDATE Member SET Discriminator = CONCAT(MemberType, ''Entity'') , [Type] = e.[Type], FirstName = e.FirstName,
                                     MiddleName = e.MiddleName, LastName = e.LastName, FullName = e.FullName, TimeZone = e.TimeZone,
-	                                    DefaultLanguage = e.DefaultLanguage, BirthDate = e.BirthDate, PhotoUrl = e.PhotoUrl, IsActive = e.IsActive
+                                        DefaultLanguage = e.DefaultLanguage, BirthDate = e.BirthDate, PhotoUrl = e.PhotoUrl, IsActive = e.IsActive
                                     FROM Member m INNER JOIN Employee e ON e.Id = m.Id')
-	                    END
+                        END
+
+                        BEGIN
+                            ALTER TABLE [Contact] DROP CONSTRAINT [FK_dbo.Contact_dbo.Member_Id]
+                        END
 
                         BEGIN
                             UPDATE [PlatformDynamicProperty] SET ObjectType = 'VirtoCommerce.CustomerModule.Core.Model.Contact' WHERE ObjectType = 'VirtoCommerce.Domain.Customer.Model.Contact'
@@ -76,23 +80,23 @@ namespace VirtoCommerce.CustomerModule.Data.Migrations
                 IF (EXISTS (SELECT * FROM __MigrationHistory WHERE ContextKey = 'VirtoCommerce.CustomerModule.Data.Migrations.Configuration'))
                     BEGIN
                         CREATE TABLE [MemberSeoInfo](
-	                        [Id] [nvarchar](128) NOT NULL,
-	                        [CreatedDate] [datetime2](7) NOT NULL,
-	                        [ModifiedDate] [datetime2](7) NULL,
-	                        [CreatedBy] [nvarchar](64) NULL,
-	                        [ModifiedBy] [nvarchar](64) NULL,
-	                        [Keyword] [nvarchar](255) NOT NULL,
-	                        [StoreId] [nvarchar](128) NULL,
-	                        [IsActive] [bit] NOT NULL,
-	                        [Language] [nvarchar](5) NULL,
-	                        [Title] [nvarchar](255) NULL,
-	                        [MetaDescription] [nvarchar](1024) NULL,
-	                        [MetaKeywords] [nvarchar](255) NULL,
-	                        [ImageAltDescription] [nvarchar](255) NULL,
-	                        [MemberId] [nvarchar](128) NULL,
+                            [Id] [nvarchar](128) NOT NULL,
+                            [CreatedDate] [datetime2](7) NOT NULL,
+                            [ModifiedDate] [datetime2](7) NULL,
+                            [CreatedBy] [nvarchar](64) NULL,
+                            [ModifiedBy] [nvarchar](64) NULL,
+                            [Keyword] [nvarchar](255) NOT NULL,
+                            [StoreId] [nvarchar](128) NULL,
+                            [IsActive] [bit] NOT NULL,
+                            [Language] [nvarchar](5) NULL,
+                            [Title] [nvarchar](255) NULL,
+                            [MetaDescription] [nvarchar](1024) NULL,
+                            [MetaKeywords] [nvarchar](255) NULL,
+                            [ImageAltDescription] [nvarchar](255) NULL,
+                            [MemberId] [nvarchar](128) NULL,
                          CONSTRAINT [PK_MemberSeoInfo] PRIMARY KEY CLUSTERED 
                         (
-	                        [Id] ASC
+                            [Id] ASC
                         )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
                         ) ON [PRIMARY]
                         
@@ -108,7 +112,7 @@ namespace VirtoCommerce.CustomerModule.Data.Migrations
                     BEGIN
                         INSERT INTO [MemberSeoInfo] ([Id], [CreatedDate], [ModifiedDate], [CreatedBy], [ModifiedBy], [Keyword], [StoreId], [IsActive], [Language], [Title], [MetaDescription], [MetaKeywords], [ImageAltDescription], [MemberId])
                               SELECT [Id], [CreatedDate], [ModifiedDate], [CreatedBy], [ModifiedBy], [Keyword], [StoreId], [IsActive], [Language], [Title], [MetaDescription], [MetaKeywords], [ImageAltDescription], [ObjectId] as [MemberId]  FROM [SeoUrlKeyword] WHERE ObjectType = 'Vendor'
-				    END");
+                    END");
 
         }
 

--- a/src/VirtoCommerce.CustomerModule.Data/Migrations/20000000000000_UpdateCustomerV2.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Migrations/20000000000000_UpdateCustomerV2.cs
@@ -59,6 +59,9 @@ namespace VirtoCommerce.CustomerModule.Data.Migrations
 
                         BEGIN
                             ALTER TABLE [Contact] DROP CONSTRAINT [FK_dbo.Contact_dbo.Member_Id]
+                            ALTER TABLE [Organization] DROP CONSTRAINT [FK_dbo.Organization_dbo.Member_Id]
+                            ALTER TABLE [Vendor] DROP CONSTRAINT [FK_dbo.Vendor_dbo.Member_Id]
+                            ALTER TABLE [Employee] DROP CONSTRAINT [FK_dbo.Employee_dbo.Member_Id]
                         END
 
                         BEGIN


### PR DESCRIPTION
### Problem
User see "500" Error when try to delete Contact in admin panel

### Solution
Drop the foreign key in migration from v2 to v3

### Proposed of changes
We have foreign key in Contact table that exist only on V2 platform. After migration to v3 this table not used.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
