### PR TITLE
VP-5638: Fix members import error

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Services/MemberService.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/MemberService.cs
@@ -147,6 +147,11 @@ namespace VirtoCommerce.CustomerModule.Data.Services
                             var dataTargetMember = existingMemberEntities.FirstOrDefault(m => m.Id == member.Id);
                             if (dataTargetMember != null)
                             {
+                                /// This extension is allow to get around breaking changes is introduced in EF Core 3.0 that leads to throw
+                                /// Database operation expected to affect 1 row(s) but actually affected 0 row(s) exception when trying to add the new children entities with manually set keys
+                                /// https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#detectchanges-honors-store-generated-key-values
+                                repository.TrackModifiedAsAddedForNewChildEntities(dataTargetMember);
+
                                 if (!dataTargetMember.GetType().IsInstanceOfType(dataSourceMember))
                                 {
                                     throw new OperationCanceledException($"Unable to update an member with type { dataTargetMember.MemberType } by an member with type { dataSourceMember.MemberType } because they aren't in the inheritance hierarchy");


### PR DESCRIPTION
### Problem
VP-5638 Error when user import file in Import & Export

### Solution
A clear and concise description of what you want to happen.

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
