### PR TITLE
HDOT-2232 Allow to extend the MemberRelationEntity

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Model/ContactEntity.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Model/ContactEntity.cs
@@ -131,7 +131,6 @@ namespace VirtoCommerce.CustomerModule.Data.Model
                     foreach (var organization in contact.Organizations)
                     {
                         var memberRelation = AbstractTypeFactory<MemberRelationEntity>.TryCreateInstance();
-
                         memberRelation.AncestorId = organization;
                         memberRelation.AncestorSequence = 1;
                         memberRelation.DescendantId = Id;
@@ -150,7 +149,6 @@ namespace VirtoCommerce.CustomerModule.Data.Model
                     foreach (var organization in contact.AssociatedOrganizations)
                     {
                         var memberRelation = AbstractTypeFactory<MemberRelationEntity>.TryCreateInstance();
-
                         memberRelation.AncestorId = organization;
                         memberRelation.AncestorSequence = 1;
                         memberRelation.DescendantId = Id;

--- a/src/VirtoCommerce.CustomerModule.Data/Model/ContactEntity.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Model/ContactEntity.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Collections;
-using System.Linq;
-using System.ComponentModel.DataAnnotations;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -131,13 +130,13 @@ namespace VirtoCommerce.CustomerModule.Data.Model
 
                     foreach (var organization in contact.Organizations)
                     {
-                        var memberRelation = new MemberRelationEntity
-                        {
-                            AncestorId = organization,
-                            AncestorSequence = 1,
-                            DescendantId = Id,
-                            RelationType = RelationType.Membership.ToString()
-                        };
+                        var memberRelation = AbstractTypeFactory<MemberRelationEntity>.TryCreateInstance();
+
+                        memberRelation.AncestorId = organization;
+                        memberRelation.AncestorSequence = 1;
+                        memberRelation.DescendantId = Id;
+                        memberRelation.RelationType = RelationType.Membership.ToString();
+
                         MemberRelations.Add(memberRelation);
                     }
                 }
@@ -150,13 +149,13 @@ namespace VirtoCommerce.CustomerModule.Data.Model
                     }
                     foreach (var organization in contact.AssociatedOrganizations)
                     {
-                        var memberRelation = new MemberRelationEntity
-                        {
-                            AncestorId = organization,
-                            AncestorSequence = 1,
-                            DescendantId = Id,
-                            RelationType = RelationType.Association.ToString()
-                        };
+                        var memberRelation = AbstractTypeFactory<MemberRelationEntity>.TryCreateInstance();
+
+                        memberRelation.AncestorId = organization;
+                        memberRelation.AncestorSequence = 1;
+                        memberRelation.DescendantId = Id;
+                        memberRelation.RelationType = RelationType.Association.ToString();
+
                         MemberRelations.Add(memberRelation);
                     }
                 }

--- a/src/VirtoCommerce.CustomerModule.Data/Model/EmployeeEntity.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Model/EmployeeEntity.cs
@@ -86,13 +86,12 @@ namespace VirtoCommerce.CustomerModule.Data.Model
                     MemberRelations = new ObservableCollection<MemberRelationEntity>();
                     foreach (var organization in employee.Organizations)
                     {
-                        var memberRelation = new MemberRelationEntity
-                        {
-                            AncestorId = organization,
-                            AncestorSequence = 1,
-                            DescendantId = Id,
-                            RelationType = RelationType.Membership.ToString()
-                        };
+                        var memberRelation = AbstractTypeFactory<MemberRelationEntity>.TryCreateInstance();
+                        memberRelation.AncestorId = organization;
+                        memberRelation.AncestorSequence = 1;
+                        memberRelation.DescendantId = Id;
+                        memberRelation.RelationType = RelationType.Membership.ToString();
+
                         MemberRelations.Add(memberRelation);
                     }
                 }

--- a/src/VirtoCommerce.CustomerModule.Data/Model/OrganizationEntity.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Model/OrganizationEntity.cs
@@ -1,8 +1,8 @@
-using System.Linq;
-using System.ComponentModel.DataAnnotations;
-using VirtoCommerce.Platform.Core.Common;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.CustomerModule.Data.Model
 {
@@ -48,13 +48,13 @@ namespace VirtoCommerce.CustomerModule.Data.Model
                 if (organization.ParentId != null)
                 {
                     MemberRelations = new ObservableCollection<MemberRelationEntity>();
-                    var memberRelation = new MemberRelationEntity
-                    {
-                        AncestorId = organization.ParentId,
-                        DescendantId = organization.Id,
-                        AncestorSequence = 1,
-                        RelationType = RelationType.Membership.ToString()
-                    };
+
+                    var memberRelation = AbstractTypeFactory<MemberRelationEntity>.TryCreateInstance();
+                    memberRelation.AncestorId = organization.ParentId;
+                    memberRelation.DescendantId = organization.Id;
+                    memberRelation.AncestorSequence = 1;
+                    memberRelation.RelationType = RelationType.Membership.ToString();
+
                     MemberRelations.Add(memberRelation);
                 }
             }


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/HDOT-2232

When filling member relations, this module currently instantiates the `MemberRelationEntity` directly, using `new MemberRelationEntity { ... }`. This approach works, but it does not allow us to override and extend member relations - even if we do so, this module will still use the `MemberRelationEntity` instead of its derived classes. So, this PR just replaces direct instantiation with the use of `AbstractTypeFactory` to allow extending the member relation.