### PR TITLE
PT-2563 Do not index empty properties except Boolean 

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
@@ -245,7 +245,15 @@ namespace VirtoCommerce.CustomerModule.Data.Search.Indexing
                 if (property.ValueType == DynamicPropertyValueType.Boolean && values.IsNullOrEmpty())
 
                 {
-                    values = new[] { (object)false };
+                    document.Add(new IndexDocumentField(propertyName, (object)false))
+                    {
+                        IsRetrievable = true,
+                        IsFilterable = true,
+                        IsCollection = isCollection,
+                        ValueType = GetDynamicPropertyIndexedValueType(property)
+                    });
+
+                    return;
                 }
 
                 if (!values.IsNullOrEmpty())

--- a/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
@@ -242,7 +242,8 @@ namespace VirtoCommerce.CustomerModule.Data.Search.Indexing
                 }
 
                 // replace empty value for Boolean property with default 'False'
-                if (values.IsNullOrEmpty() && property.ValueType == DynamicPropertyValueType.Boolean)
+                if (property.ValueType == DynamicPropertyValueType.Boolean && values.IsNullOrEmpty())
+
                 {
                     values = new[] { (object)false };
                 }

--- a/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
@@ -13,7 +13,6 @@ namespace VirtoCommerce.CustomerModule.Data.Search.Indexing
 {
     public class MemberDocumentBuilder : IIndexDocumentBuilder
     {
-        public static readonly string NoValueString = "__null";
         private readonly IMemberService _memberService;
         private readonly IDynamicPropertySearchService _dynamicPropertySearchService;
 
@@ -217,81 +216,56 @@ namespace VirtoCommerce.CustomerModule.Data.Search.Indexing
         {
             var propertyName = property.Name?.ToLowerInvariant();
 
-            if (!string.IsNullOrEmpty(propertyName))
+            if (string.IsNullOrEmpty(propertyName))
             {
-                IList<object> values = null;
-                var isCollection = property.IsDictionary || property.IsArray;
+                return;
+            }
 
-                if (objectProperty != null)
+            IList<object> values = null;
+            var isCollection = property.IsDictionary || property.IsArray;
+
+            if (objectProperty != null)
+            {
+                if (!objectProperty.IsDictionary)
                 {
-                    if (!objectProperty.IsDictionary)
-                    {
-                        values = objectProperty.Values.Where(x => x.Value != null)
-                            .Select(x => x.Value)
-                            .ToList();
-                    }
-                    else
-                    {
-                        //add all locales in dictionary to searchIndex
-                        values = objectProperty.Values.Select(x => x.Value)
-                                                .Cast<DynamicPropertyDictionaryItem>()
-                                                .Where(x => !string.IsNullOrEmpty(x.Name))
-                                                .Select(x => x.Name)
-                                                .ToList<object>();
-                    }
+                    values = objectProperty.Values.Where(x => x.Value != null)
+                        .Select(x => x.Value)
+                        .ToList();
                 }
-
-                // replace empty value for Boolean property with default 'False'
-                if (property.ValueType == DynamicPropertyValueType.Boolean && values.IsNullOrEmpty())
+                else
                 {
-                    document.Add(new IndexDocumentField(propertyName, false)
-                    {
-                        IsRetrievable = true,
-                        IsFilterable = true,
-                        IsCollection = isCollection,
-                        ValueType = GetDynamicPropertyIndexedValueType(property)
-                    });
-
-                    return;
-                }
-
-                if (!values.IsNullOrEmpty())
-                {
-                    document.Add(new IndexDocumentField(propertyName, values)
-                    {
-                        IsRetrievable = true,
-                        IsFilterable = true,
-                        IsCollection = isCollection,
-                        ValueType = GetDynamicPropertyIndexedValueType(property)
-                    });
+                    //add all locales in dictionary to searchIndex
+                    values = objectProperty.Values.Select(x => x.Value)
+                                            .Cast<DynamicPropertyDictionaryItem>()
+                                            .Where(x => !string.IsNullOrEmpty(x.Name))
+                                            .Select(x => x.Name)
+                                            .ToList<object>();
                 }
             }
-        }
 
-        private IndexDocumentFieldValueType GetDynamicPropertyIndexedValueType(DynamicProperty property)
-        {
-            switch (property?.ValueType ?? DynamicPropertyValueType.Undefined)
+            // replace empty value for Boolean property with default 'False'
+            if (property.ValueType == DynamicPropertyValueType.Boolean && values.IsNullOrEmpty())
             {
-                case DynamicPropertyValueType.ShortText:
-                case DynamicPropertyValueType.Html:
-                case DynamicPropertyValueType.LongText:
-                case DynamicPropertyValueType.Image:
-                    return IndexDocumentFieldValueType.String;
+                document.Add(new IndexDocumentField(propertyName, false)
+                {
+                    IsRetrievable = true,
+                    IsFilterable = true,
+                    IsCollection = isCollection,
+                    ValueType = property.ValueType.ToIndexedDocumentFieldValueType()
+                });
 
-                case DynamicPropertyValueType.Integer:
-                    return IndexDocumentFieldValueType.Integer;
+                return;
+            }
 
-                case DynamicPropertyValueType.Decimal:
-                    return IndexDocumentFieldValueType.Double;
-
-                case DynamicPropertyValueType.DateTime:
-                    return IndexDocumentFieldValueType.DateTime;
-
-                case DynamicPropertyValueType.Boolean:
-                    return IndexDocumentFieldValueType.Boolean;
-
-                default:
-                    return IndexDocumentFieldValueType.Undefined;
+            if (!values.IsNullOrEmpty())
+            {
+                document.Add(new IndexDocumentField(propertyName, values)
+                {
+                    IsRetrievable = true,
+                    IsFilterable = true,
+                    IsCollection = isCollection,
+                    ValueType = property.ValueType.ToIndexedDocumentFieldValueType()
+                });
             }
         }
 

--- a/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
@@ -243,9 +243,8 @@ namespace VirtoCommerce.CustomerModule.Data.Search.Indexing
 
                 // replace empty value for Boolean property with default 'False'
                 if (property.ValueType == DynamicPropertyValueType.Boolean && values.IsNullOrEmpty())
-
                 {
-                    document.Add(new IndexDocumentField(propertyName, (object)false))
+                    document.Add(new IndexDocumentField(propertyName, false)
                     {
                         IsRetrievable = true,
                         IsFilterable = true,

--- a/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
@@ -241,16 +241,26 @@ namespace VirtoCommerce.CustomerModule.Data.Search.Indexing
                     }
                 }
 
-                // TODO PT-2562 handle null values correctly
+                // replace empty value for Boolean property with default 'False'
+                if (values.IsNullOrEmpty() && property.ValueType == DynamicPropertyValueType.Boolean)
+                {
+                    values = new[] { (object)false };
+                }
+
                 if (!values.IsNullOrEmpty())
                 {
-                    var valueType = GetDynamicPropertyDefaultValue(property);
-                    document.Add(new IndexDocumentField(propertyName, values) { IsRetrievable = true, IsFilterable = true, IsCollection = isCollection, ValueType = valueType });
+                    document.Add(new IndexDocumentField(propertyName, values)
+                    {
+                        IsRetrievable = true,
+                        IsFilterable = true,
+                        IsCollection = isCollection,
+                        ValueType = GetDynamicPropertyIndexedValueType(property)
+                    });
                 }
             }
         }
 
-        private IndexDocumentFieldValueType GetDynamicPropertyDefaultValue(DynamicProperty property)
+        private IndexDocumentFieldValueType GetDynamicPropertyIndexedValueType(DynamicProperty property)
         {
             switch (property?.ValueType ?? DynamicPropertyValueType.Undefined)
             {

--- a/src/VirtoCommerce.CustomerModule.Data/VirtoCommerce.CustomerModule.Data.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data/VirtoCommerce.CustomerModule.Data.csproj
@@ -25,8 +25,8 @@
         <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.57.0" />
         <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.57.0" />
-        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.15.0" />
-        <PackageReference Include="VirtoCommerce.SearchModule.Data" Version="3.15.0" />
+        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.16.0" />
+        <PackageReference Include="VirtoCommerce.SearchModule.Data" Version="3.16.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\VirtoCommerce.CustomerModule.Core\VirtoCommerce.CustomerModule.Core.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Web/module.manifest
+++ b/src/VirtoCommerce.CustomerModule.Web/module.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Customer</id>
   <version>3.32.0</version>
@@ -23,7 +23,7 @@
   <moduleType>VirtoCommerce.CustomerModule.Web.Module, VirtoCommerce.CustomerModule.Web</moduleType>
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.0.0" />
-    <dependency id="VirtoCommerce.Search" version="3.15.0" />
+    <dependency id="VirtoCommerce.Search" version="3.16.0" />
     <dependency id="VirtoCommerce.Store" version="3.0.1" />
   </dependencies>
   <groups>


### PR DESCRIPTION
## Description
Skip indexation for empty Dynamic Properties properties. Use default False value for empty Dynamic Properties of Boolean type.
## References
### QA-test: PT-2565
### Jira-link: https://virtocommerce.atlassian.net/browse/PT-2562
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.33.0-pr-154.zip
