### PR TITLE
fix: Expire customer search region on ApplicationUser change

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Handlers/SecurtityAccountChangesEventHandler.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Handlers/SecurtityAccountChangesEventHandler.cs
@@ -20,6 +20,7 @@ namespace VirtoCommerce.CustomerModule.Data.Handlers
         {
             foreach (var change in @event.ChangedEntries ?? Array.Empty<GenericChangedEntry<ApplicationUser>>())
             {
+                CustomerSearchCacheRegion.ExpireRegion();
                 CustomerCacheRegion.ExpireMemberById(change.NewEntry.MemberId);
 
                 if (!change.NewEntry.MemberId.EqualsInvariant(change.OldEntry.MemberId))


### PR DESCRIPTION
## Description
Expire customer search region on ApplicationUser change. Otherwise, the cache will be inconsistent for the search. That can cause different results for the contact.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4681
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.34.0-pr-157.zip
