### PR TITLE
Fix double id parameter

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
@@ -329,7 +329,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
                 return Forbid();
             }
             await _memberService.SaveChangesAsync(contacts);
-            return NoContent(); // TODO: write here return Ok(contacts) when updating storefront AutoRest proxies to VC v3            
+            return NoContent(); // TODO: write here return Ok(contacts) when updating storefront AutoRest proxies to VC v3
         }
 
         /// <summary>
@@ -361,7 +361,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
             }
 
             await _memberService.SaveChangesAsync(organizations);
-            return NoContent(); // TODO: write here return Ok(organizations) when updating storefront AutoRest proxies to VC v3            
+            return NoContent(); // TODO: write here return Ok(organizations) when updating storefront AutoRest proxies to VC v3
         }
 
         /// <summary>
@@ -393,7 +393,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
                 return Forbid();
             }
             await _memberService.SaveChangesAsync(organizations);
-            return NoContent(); // TODO: write here return Ok(organizations) when updating storefront AutoRest proxies to VC v3            
+            return NoContent(); // TODO: write here return Ok(organizations) when updating storefront AutoRest proxies to VC v3
         }
 
         /// <summary>
@@ -441,7 +441,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         }
 
         /// <summary>
-        /// Get plenty organizations 
+        /// Get plenty organizations
         /// </summary>
         /// <param name="ids">Organization ids</param>
         [HttpGet]
@@ -507,7 +507,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
 
 
         /// <summary>
-        /// Get plenty contacts 
+        /// Get plenty contacts
         /// </summary>
         /// <param name="ids">contact IDs</param>
         [HttpGet]
@@ -569,7 +569,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         }
 
         /// <summary>
-        /// Get plenty vendors 
+        /// Get plenty vendors
         /// </summary>
         /// <param name="ids">Vendors IDs</param>
         [HttpGet]
@@ -650,7 +650,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         }
 
         /// <summary>
-        /// Get plenty employees 
+        /// Get plenty employees
         /// </summary>
         /// <param name="ids">contact IDs</param>
         [HttpGet]
@@ -668,7 +668,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         /// <param name="id">member Id</param>
         [HttpGet]
         [Route("members/{id}/organizations")]
-        public async Task<ActionResult<Organization[]>> GetMemberOrganizations([FromQuery] string id)
+        public async Task<ActionResult<Organization[]>> GetMemberOrganizations(string id)
         {
             var members = await _memberService.GetByIdsAsync(new[] { id }, null, new[] { typeof(Employee).Name, typeof(Contact).Name });
             var member = members.FirstOrDefault();


### PR DESCRIPTION
The `VirtoCommerce.CustomerModule.Web.Controllers.Api.CustomerModuleController.GetMemberOrganizations()` action has its `id` parameter specified dually - in the route template as `"members/{id}/organizations"` and in the query with the `[FromQuery]` attribute. This results in the same parameter appearing in two forms, as query- and path-sourced:
```json
"/api/members/{id}/organizations": {
    "get": {
        "tags": [
            "Companies and Contacts"
        ],
        "summary": "Get all member organizations",
        "operationId": "CustomerModule_GetMemberOrganizations",
        "parameters": [
            {
                "name": "id",
                "in": "query",
                "description": "member Id",
                "schema": {
                    "type": "string"
                }
            },
            {
                "name": "id",
                "in": "path",
                "required": true,
                "schema": {
                    "type": "string"
                }
            }
        ],
        "responses": "..."
    }
}
```
In addition only the path version is required, but the query version is actually used in code. If you pass only the path id, you'll get a 500. As a result consumers are forced to pass the id twice (one to satisfy the required parameter, and the other for the controller to actually use).

After this fix, only the in-path parameter remains, but the change seems to be backward-compatible (tested this locally).