### PR TITLE
PT-13447: System.NullReferenceException if Roles collection is null

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Search/Indexing/MemberDocumentBuilder.cs
@@ -6,6 +6,7 @@ using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
+using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.SearchModule.Core.Extensions;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
@@ -217,12 +218,12 @@ namespace VirtoCommerce.CustomerModule.Data.Search.Indexing
 
             document.AddFilterableCollection("Role", contact
                 .SecurityAccounts
-                .SelectMany(x => x.Roles)
+                .SelectMany(x => x.Roles ?? Enumerable.Empty<Role>())
                 .Select(x => x.NormalizedName)
                 .ToList());
             document.AddFilterableCollection("RoleId", contact
                 .SecurityAccounts
-                .SelectMany(x => x.Roles)
+                .SelectMany(x => x.Roles ?? Enumerable.Empty<Role>())
                 .Select(x => x.Id)
                 .ToList());
         }


### PR DESCRIPTION
## Description
fix: System.NullReferenceException during adding in the Contact Index if Roles collection is null.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-13447
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.405.0-pr-224-2745.zip
