### PR TITLE
PT-14710: use appropriate permission to search member

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Controllers/Api/CustomerModuleController.cs
@@ -65,7 +65,7 @@ namespace VirtoCommerce.CustomerModule.Web.Controllers.Api
         [Route("members/search")]
         public async Task<ActionResult<MemberSearchResult>> SearchMember([FromBody] MembersSearchCriteria criteria)
         {
-            if (!(await AuthorizeAsync(criteria, ModuleConstants.Security.Permissions.Access)).Succeeded)
+            if (!(await AuthorizeAsync(criteria, ModuleConstants.Security.Permissions.Read)).Succeeded)
             {
                 return Forbid();
             }


### PR DESCRIPTION
## Description

fix incorrect permission checking in membersr search action. There should be customer:read permission instead of customer:access

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-14710
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.411.0-pr-231-b886.zip
