### PR TITLE
VCST-605: Mark AddressEntity.StateProvince as Obsolete

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Model/AddressEntity.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Model/AddressEntity.cs
@@ -32,6 +32,7 @@ namespace VirtoCommerce.CustomerModule.Data.Model
         [StringLength(64)]
         public string CountryCode { get; set; }
 
+        [Obsolete("Not being called. Use either `RegionId` or `RegionName` property.", DiagnosticId = "VC0008", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         [StringLength(128)]
         public string StateProvince { get; set; }
 
@@ -85,7 +86,7 @@ namespace VirtoCommerce.CustomerModule.Data.Model
 
         public override string ToString()
         {
-            return $"{FirstName} {LastName}, {Line1} {Line2}, {City}, {StateProvince} {PostalCode} {CountryName}";
+            return $"{FirstName} {LastName}, {Line1} {Line2}, {City}, {RegionName} {PostalCode} {CountryName}";
         }
 
         #endregion
@@ -152,7 +153,6 @@ namespace VirtoCommerce.CustomerModule.Data.Model
             target.PostalCode = PostalCode;
             target.RegionId = RegionId;
             target.RegionName = RegionName;
-            target.StateProvince = StateProvince;
             target.Type = Type;
             target.City = City;
             target.Name = Name;


### PR DESCRIPTION
## Description
fix: Marks AddressEntity.StateProvince as Obsolete with Diagnostic Id = VC0008 . Not being called. Use either RegionId or RegionName property.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-605
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.802.0-pr-236-8305.zip
