### PR TITLE
VCST-667: Have access to manage icon with customer:read permission

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Web/Scripts/customer.js
+++ b/src/VirtoCommerce.CustomerModule.Web/Scripts/customer.js
@@ -102,7 +102,11 @@ angular.module(moduleName, ['virtoCommerce.customerModule.common'])
                 };
                 var iconWidget = {
                     controller: 'virtoCommerce.customerModule.memberIconWidgetController',
-                    template: 'Modules/$(VirtoCommerce.Customer)/Scripts/widgets/memberIconWidget.tpl.html'
+                    template: 'Modules/$(VirtoCommerce.Customer)/Scripts/widgets/memberIconWidget.tpl.html',
+                    isVisible: function (blade) {
+                        return authService.checkPermission('customer:create') ||
+                            authService.checkPermission('customer:update');
+                    }
                 }
                 var indexWidget = {
                     documentType: 'Member',


### PR DESCRIPTION
## Description
fix: Hides icon widget if an employee doesn't have either customer:create or customer:update permission.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-667
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.803.0-pr-237-3499.zip
