### PR TITLE
fix: Check that memberId is not null or empty in MemberService.GetByIdAsync

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Services/MemberService.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/MemberService.cs
@@ -139,7 +139,12 @@ namespace VirtoCommerce.CustomerModule.Data.Services
 
         public virtual async Task<Member> GetByIdAsync(string memberId, string responseGroup = null, string memberType = null)
         {
-            var members = await GetByIdsAsync(new[] { memberId }, responseGroup, !string.IsNullOrEmpty(memberType) ? new[] { memberType } : null);
+            if (string.IsNullOrEmpty(memberId))
+            {
+                return null;
+            }
+
+            var members = await GetByIdsAsync([memberId], responseGroup, !string.IsNullOrEmpty(memberType) ? [memberType] : null);
             return members.FirstOrDefault();
         }
 


### PR DESCRIPTION
## Description
 Fix ArgumentNullException in CreateChangeTokenForKey when memberId is null in MemberService.GetByIdAsync
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.806.0-pr-240-3325.zip