### PR TITLE
VCST-3631: Fix dynamic properties patching

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Model/MemberEntity.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Model/MemberEntity.cs
@@ -78,9 +78,9 @@ namespace VirtoCommerce.CustomerModule.Data.Model
                   var property = AbstractTypeFactory<DynamicObjectProperty>.TryCreateInstance();
                   property.Id = x.First()?.PropertyId;
                   property.Name = x.FirstOrDefault()?.PropertyName;
-                  property.Values = x.Select(v => v.ToModel(AbstractTypeFactory<DynamicPropertyObjectValue>.TryCreateInstance())).ToArray();
+                  property.Values = x.Select(v => v.ToModel(AbstractTypeFactory<DynamicPropertyObjectValue>.TryCreateInstance())).ToList();
                   return property;
-              }).ToArray();
+              }).ToList();
 
             return member;
         }


### PR DESCRIPTION
## Description
1. Create a boolean dynamic property `MyDynamicProperty` for the organization type
2. Add a value for this property to some organization by executing the following request:
```
PATCH /api/members/{organization-id}
```
```json
[
    {
        "op": "add",
        "path": "/dynamicProperties/-",
        "value": {
            "name": "MyDynamicProperty",
            "valueType": "Boolean",
            "values": [
                {
                    "value": true
                }
            ]
        }
    }
]
```
3. If you need to change the existing value, you should send a different payload:
```json
[
    {
        "op": "replace",
        "path": "/dynamicProperties/0/values/0/value",
        "value": true
    }
]
```
You cannot reference the property by its name in this case, so make sure you are using the correct property index.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3631
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.835.0-pr-276-c7e9.zip