### PR TITLE
VCST4880: Fix Specified key was too long for MySQL

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data.MySql/Migrations/20250605144726_AddCustomerPreferences.cs
+++ b/src/VirtoCommerce.CustomerModule.Data.MySql/Migrations/20250605144726_AddCustomerPreferences.cs
@@ -36,11 +36,11 @@ namespace VirtoCommerce.CustomerModule.Data.MySql.Migrations
                 })
                 .Annotation("MySql:CharSet", "utf8mb4");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_CustomerPreference_UserId_Name",
-                table: "CustomerPreference",
-                columns: new[] { "UserId", "Name" },
-                unique: true);
+            // MySQL InnoDB max index key length is 3072 bytes with utf8mb4 (4 bytes/char).
+            // UserId(128) + Name(1024) = 1152 chars * 4 = 4608 bytes — exceeds limit.
+            // Use a 640-char prefix on Name: (128+640) * 4 = 3072 bytes — fits exactly.
+            migrationBuilder.Sql(@"CREATE UNIQUE INDEX `IX_CustomerPreference_UserId_Name`
+                ON `CustomerPreference` (`UserId`, `Name`(640));");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Description
fix: Specified key was too long, max key length is 3072 bytes for MySQL.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4880
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1004.0-pr-296-1c3f.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MySQL migration to create a prefix-based unique index, which could allow rare collisions for `Name` values that only differ after 640 chars and impacts data integrity constraints.
> 
> **Overview**
> Fixes MySQL migration failure when creating the unique index on `CustomerPreference` by replacing the EF `CreateIndex` call with raw SQL that creates `IX_CustomerPreference_UserId_Name` using a `Name` prefix length of 640 characters to fit InnoDB’s 3072-byte index limit under `utf8mb4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c3f2ac50126c0a07701036367718395e5fc5476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->