### PR TITLE
VCST-4516: Update SEO widget reference to use Seo module instead of Core

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
+++ b/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
 
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-4516" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0-alpha.74-vcst-4516" />
+    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
+++ b/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
@@ -12,7 +12,7 @@
 
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-4516" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0-alpha.74-vcst-4516" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
+++ b/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
 
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-45160" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-4516" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
+++ b/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
@@ -9,12 +9,12 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
+
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1003.0-alpha.1690-vcst-45160" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1002.0-alpha.74-vcst-4516" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CustomerModule.Data.MySql/VirtoCommerce.CustomerModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data.MySql/VirtoCommerce.CustomerModule.Data.MySql.csproj
@@ -6,12 +6,12 @@
     <noWarn>NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Data\VirtoCommerce.CustomerModule.Data.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Data.PostgreSql/VirtoCommerce.CustomerModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data.PostgreSql/VirtoCommerce.CustomerModule.Data.PostgreSql.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Data\VirtoCommerce.CustomerModule.Data.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Data.SqlServer/VirtoCommerce.CustomerModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data.SqlServer/VirtoCommerce.CustomerModule.Data.SqlServer.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Data\VirtoCommerce.CustomerModule.Data.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Data/VirtoCommerce.CustomerModule.Data.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data/VirtoCommerce.CustomerModule.Data.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1013.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1013.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Core\VirtoCommerce.CustomerModule.Core.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Web/Scripts/customer.js
+++ b/src/VirtoCommerce.CustomerModule.Web/Scripts/customer.js
@@ -83,12 +83,12 @@ angular.module(moduleName, [])
         '$rootScope', '$state', 'platformWebApp.mainMenuService', 'platformWebApp.authService', 'platformWebApp.permissionScopeResolver',
         'platformWebApp.widgetService', 'platformWebApp.settings', 'platformWebApp.userProfileIconService', 'platformWebApp.metaFormsService',
         'virtoCommerce.customerModule.memberTypesResolverService', 'virtoCommerce.customerModule.predefinedSearchFilters', 'virtoCommerce.customerModule.members',
-        'platformWebApp.toolbarService', 'platformWebApp.bladeNavigationService',
+        'platformWebApp.toolbarService', 'platformWebApp.bladeNavigationService', 'virtoCommerce.storeModule.stores',
         function (
             $rootScope, $state, mainMenuService, authService, scopeResolver,
             widgetService, settings, userProfileIconService, metaFormsService,
             memberTypesResolverService, predefinedSearchFilters, membersApi,
-            toolbarService, bladeNavigationService) {
+            toolbarService, bladeNavigationService, storesApi) {
             //Register module in main menu
             var menuItem = {
                 path: 'browse/member',
@@ -127,13 +127,14 @@ angular.module(moduleName, [])
                 isVisible: function (blade) { return !blade.isNew && authService.checkPermission('platform:dynamic_properties:read'); }
             };
             var vendorSeoWidget = {
-                controller: 'virtoCommerce.coreModule.seo.seoWidgetController',
-                template: 'Modules/$(VirtoCommerce.Core)/Scripts/SEO/widgets/seoWidget.tpl.html',
+                controller: 'virtoCommerce.seo.seoWidgetController',
+                template: 'Modules/$(VirtoCommerce.Seo)/Scripts/widgets/seo-widget.html',
                 objectType: 'Vendor',
                 getDefaultContainerId: function (blade) { return undefined; },
                 getLanguages: function (blade) {
                     return settings.getValues({ id: 'VirtoCommerce.Core.General.Languages' });
                 },
+                getStoreDataSource: function () { return function (criteria) { return storesApi.search(criteria); }; },
                 isVisible: function (blade) { return !blade.isNew; }
             };
             var iconWidget = {

--- a/src/VirtoCommerce.CustomerModule.Web/module.manifest
+++ b/src/VirtoCommerce.CustomerModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1013.0</platformVersion>
+  <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.1003.0-alpha.1690-vcst-4516" />
     <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />

--- a/src/VirtoCommerce.CustomerModule.Web/module.manifest
+++ b/src/VirtoCommerce.CustomerModule.Web/module.manifest
@@ -6,10 +6,10 @@
 
   <platformVersion>3.1016.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1003.0-alpha.1690-vcst-4516" />
+    <dependency id="VirtoCommerce.Core" version="3.1003.0" />
     <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
     <dependency id="VirtoCommerce.Search" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Seo" version="3.1002.0-alpha.74-vcst-4516" />
+    <dependency id="VirtoCommerce.Seo" version="3.1002.0" />
     <dependency id="VirtoCommerce.Store" version="3.1000.0" />
   </dependencies>
 

--- a/src/VirtoCommerce.CustomerModule.Web/module.manifest
+++ b/src/VirtoCommerce.CustomerModule.Web/module.manifest
@@ -6,10 +6,10 @@
 
   <platformVersion>3.1013.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1003.0-alpha.1690-vcst-4516" />
     <dependency id="VirtoCommerce.Notifications" version="3.1000.0" />
     <dependency id="VirtoCommerce.Search" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Seo" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Seo" version="3.1002.0-alpha.74-vcst-4516" />
     <dependency id="VirtoCommerce.Store" version="3.1000.0" />
   </dependencies>
 


### PR DESCRIPTION
## Description

- Updated SEO widget registration for Vendor to use new controller and template from VirtoCommerce.Seo module
- Added `getStoreDataSource` callback for paginated store dropdown in SEO detail blade

### Changes

**customer.js**:
- Controller: `virtoCommerce.coreModule.seo.seoWidgetController` → `virtoCommerce.seo.seoWidgetController`
- Template: `Modules/$(VirtoCommerce.Core)/Scripts/SEO/widgets/seoWidget.tpl.html` → `Modules/$(VirtoCommerce.Seo)/Scripts/widgets/seo-widget.html`
- Added `virtoCommerce.storeModule.stores` injection and `getStoreDataSource` to widget config

### Related

Companion PRs: vc-module-seo, vc-module-core, vc-module-catalog, vc-module-store, vc-module-catalog-publishing, vc-docs

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4516
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1005.0-pr-297-3e0b.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates module/platform package versions and rewires the vendor SEO widget to a new controller/template, which can introduce runtime/UI regressions if the new Seo widget contracts differ.
> 
> **Overview**
> **Vendor SEO widget wiring is updated** to use the `VirtoCommerce.Seo` module’s controller/template instead of the Core module, and the widget now supplies `getStoreDataSource` (backed by `virtoCommerce.storeModule.stores.search`) for the store selector.
> 
> **Dependency alignment is refreshed** by bumping `VirtoCommerce.Platform.*` (and related Core/Seo module) package versions in the module `.csproj`s and updating `module.manifest` `platformVersion`/dependency versions accordingly; EF Core design package is also updated to `10.0.5` for DB providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e0b530970a2d314d54ed36a9af5a787f37b6552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->