### PR TITLE
VCST-5374: Fix org members shown permanent lockout code for a temporary lock

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
@@ -31,7 +31,13 @@ public class OrganizationIdRequestValidator(
         // return the global error immediately without checking org-level state.
         if (context.User != null && IsGloballyLocked(context.User))
         {
-            return [ErrorDescriber.UserIsLockedOut()];
+            // Distinguish a permanent lock (LockoutEnd == DateTime.MaxValue) from a temporary
+            // failed-attempt lock, mirroring how the platform's BaseUserSignInValidator decides.
+            // Otherwise org members get the permanent-worded code for a self-clearing 15-min lock.
+            var permanentLockOut = context.User.LockoutEnd == DateTime.MaxValue.ToUniversalTime();
+            return [permanentLockOut
+                ? ErrorDescriber.UserIsLockedOut()
+                : SecurityErrorDescriber.UserIsTemporaryLockedOut()];
         }
 
         var availableOrganizationIds = await GetAvailableOrganizationIds(context);

--- a/tests/VirtoCommerce.CustomerModule.Tests/OrganizationIdRequestValidatorTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/OrganizationIdRequestValidatorTests.cs
@@ -138,6 +138,58 @@ public class OrganizationIdRequestValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_UserTemporarilyLocked_ReturnsTemporaryLockoutError()
+    {
+        //Arrange — org member with an active TEMPORARY lock (future end, NOT DateTime.MaxValue),
+        // e.g. after exceeding the failed-attempt threshold. VCST-5374: this must surface the
+        // temporary lockout code, not the permanent one.
+        _memberServiceMock.Setup(s => s.GetByIdAsync(MemberId, null, null))
+            .ReturnsAsync(new Contact { Id = MemberId, Organizations = [OrgId] });
+
+        var user = new ApplicationUser
+        {
+            Id = UserId,
+            MemberId = MemberId,
+            LockoutEnabled = true,
+            LockoutEnd = DateTimeOffset.UtcNow.AddMinutes(15)
+        };
+
+        //Act
+        var result = await GetValidator().ValidateAsync(BuildContext(OrgId, user: user));
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, result[0].Error);
+        Assert.NotEqual("user_is_locked_out", result[0].Code);
+        Assert.Equal("user_is_temporary_locked_out", result[0].Code);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UserPermanentlyLocked_ReturnsGlobalLockoutError()
+    {
+        //Arrange — org member with a PERMANENT lock (LockoutEnd == DateTime.MaxValue).
+        // Regression guard: the permanent code must still be returned.
+        _memberServiceMock.Setup(s => s.GetByIdAsync(MemberId, null, null))
+            .ReturnsAsync(new Contact { Id = MemberId, Organizations = [OrgId] });
+
+        var user = new ApplicationUser
+        {
+            Id = UserId,
+            MemberId = MemberId,
+            LockoutEnabled = true,
+            LockoutEnd = DateTime.MaxValue.ToUniversalTime()
+        };
+
+        //Act
+        var result = await GetValidator().ValidateAsync(BuildContext(OrgId, user: user));
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, result[0].Error);
+        Assert.Equal("user_is_locked_out", result[0].Code);
+    }
+
+    [Fact]
     public async Task ValidateAsync_UserLockedInOrg_ReturnsOrgError()
     {
         //Arrange


### PR DESCRIPTION
> 🤖 Opened by the QA auto-fix pipeline. **DO NOT MERGE until human review + deploy verification.** Not auto-merged.

## Summary
Org-member accounts that hit a temporary failed-attempt lockout were shown the **permanent** error code `user_is_locked_out` ("…contact your administrator") instead of the temporary `user_is_temporary_locked_out`, even though the lock self-clears in ~15 min. Fixes **VCST-5374**.

## Root cause
`OrganizationIdRequestValidator` (an OpenIddict `ITokenRequestValidator`, Priority 50) early-returns `ErrorDescriber.UserIsLockedOut()` for **any** active lock — `IsGloballyLocked` only checks `LockoutEnd > now`, never distinguishing a temporary lock from a permanent one. Because it runs ahead of the platform's `BaseUserSignInValidator` (Priority 0), which *does* split temp vs permanent, org members never reach the correct code. Non-org users resolve no org id → this validator returns `[]` → the base validator emits the correct temporary code.

## Fix
`src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs` — inside the existing highest-priority early-return, split temp vs permanent using the **same comparison the platform uses** (`context.User.LockoutEnd == DateTime.MaxValue.ToUniversalTime()`):

```csharp
var permanentLockOut = context.User.LockoutEnd == DateTime.MaxValue.ToUniversalTime();
return [permanentLockOut
    ? ErrorDescriber.UserIsLockedOut()
    : SecurityErrorDescriber.UserIsTemporaryLockedOut()];
```

`SecurityErrorDescriber` lives in `VirtoCommerce.Platform.Security.OpenIddict` (already imported). The early-return is preserved (global lock keeps highest priority and **login is still denied** — BL-AUTH-003); only the returned **code** is corrected for the temporary case. The org-block branch (`membership.IsCurrentlyLocked` → `UserIsLockedInOrganization`, BL-AUTH-013 / VCST-5028) is untouched. Minimal diff: 1 production hunk + 2 added tests, no contract/DTO/migration/manifest change.

I chose the **split** option (vs returning `[]` to defer to `BaseUserSignInValidator`) because it preserves the documented "global lock has the highest priority" early-return semantics and mirrors the platform's exact decision inline, making the behavior provable in a focused unit test without relying on a downstream validator's ordering.

## Test (red → green)
Added to `tests/VirtoCommerce.CustomerModule.Tests/OrganizationIdRequestValidatorTests.cs` (no existing test modified):
- `ValidateAsync_UserTemporarilyLocked_ReturnsTemporaryLockoutError` — org member, `LockoutEnd = now + 15 min` (not MaxValue) ⇒ `Code == "user_is_temporary_locked_out"`, **not** `"user_is_locked_out"`. **Failed on old code** (`Assert.NotEqual` — got `user_is_locked_out`), **passes with the fix**.
- `ValidateAsync_UserPermanentlyLocked_ReturnsGlobalLockoutError` — regression guard, `LockoutEnd = DateTime.MaxValue.ToUniversalTime()` ⇒ `Code == "user_is_locked_out"`. Passes both before and after.

Red run: `1 Failed, 9 Passed` (only the new temporary test fails). Green run: **70 Passed, 0 Failed** (whole `VirtoCommerce.CustomerModule.Tests` project; all pre-existing tests unchanged and green).

## Verification
- [x] `dotnet build -c Debug -p:NuGetAudit=false` → **Build succeeded, 0 Warning(s), 0 Error(s)**
- [x] `dotnet test --nologo -p:NuGetAudit=false` → **70 Passed, 0 Failed, 0 Skipped**
- [ ] SonarCloud quality gate (PR CI) — changed lines are clean (no new bug/vuln/hotspot); the 2 new tests cover the new branch on both sides.

## ⚠ Needs deploy verification
Statically verified only (unit-proven). The live `/connect/token` symptom from VCST-5374 must be re-confirmed after this module's alpha artifact is built and deployed to QA — regression pipeline + `/qa-regression auth` + `/qa-verify-fix VCST-5374`.

## Reviewer notes
- BL-AUTH-003 preserved: a temporarily locked org user is still **denied** login; only the surfaced code/wording changes from permanent to temporary.
- The comparison `LockoutEnd == DateTime.MaxValue.ToUniversalTime()` is byte-for-byte what `vc-platform` `BaseUserSignInValidator` uses, so the temp/permanent boundary is consistent across the two validators. `LockoutEnd` is `DateTimeOffset?`; the `DateTimeOffset == DateTime` comparison compiles via implicit conversion (same as the platform).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5374
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1013.0-pr-303-fe3b.zip