### PR TITLE
VCST-5303: Cache per-request member resolution (drop per-call UserManager construction)

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/Services/MemberResolver.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/MemberResolver.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
@@ -8,11 +10,13 @@ using VirtoCommerce.Platform.Core.Security;
 
 namespace VirtoCommerce.CustomerModule.Data.Services
 {
-    public class MemberResolver(IMemberService memberService, Func<UserManager<ApplicationUser>> userManagerFactory) : IMemberResolver
+    public class MemberResolver(IMemberService memberService, Func<UserManager<ApplicationUser>> userManagerFactory, IHttpContextAccessor httpContextAccessor) : IMemberResolver
     {
+        private const string RequestCacheKey = "MemberResolver:RequestCache";
+
         [Obsolete("Use new constructor without IPlatformMemoryCache argument", DiagnosticId = "VC0012", UrlFormat = "https://docs.virtocommerce.org/platform/user-guide/versions/virto3-products-versions/")]
         public MemberResolver(IMemberService memberService, Func<UserManager<ApplicationUser>> userManagerFactory, IPlatformMemoryCache platformMemoryCache)
-            : this(memberService, userManagerFactory)
+            : this(memberService, userManagerFactory, (IHttpContextAccessor)null)
         {
         }
 
@@ -23,7 +27,41 @@ namespace VirtoCommerce.CustomerModule.Data.Services
                 throw new ArgumentNullException(nameof(userId));
             }
 
-            return ResolveMemberByIdInternalAsync(userId);
+            // Per-request cache: getFullCart resolves the same shopper's userId many times per request,
+            // and each uncached call constructs a fresh CustomUserManager, which takes a process-global
+            // Meter lock unconditionally (.NET 9 UserManagerMetrics) -> lock convoy under load.
+            var httpContext = httpContextAccessor?.HttpContext;
+            if (httpContext is null)
+            {
+                // No ambient request (e.g. background job) - nothing to scope the cache to.
+                return ResolveMemberByIdInternalAsync(userId);
+            }
+
+            var cache = GetOrCreateRequestCache(httpContext);
+
+            // Lazy guarantees the resolution runs once even if two callers miss the same key concurrently.
+            var lazyTask = cache.GetOrAdd(userId, static (id, resolver) => new Lazy<Task<Member>>(() => resolver.ResolveMemberByIdInternalAsync(id)), this);
+
+            return lazyTask.Value;
+        }
+
+        private static ConcurrentDictionary<string, Lazy<Task<Member>>> GetOrCreateRequestCache(HttpContext httpContext)
+        {
+            // HttpContext.Items is not thread-safe; the O(1) container get-or-create runs under the lock.
+            // The expensive resolution stays outside it, via GetOrAdd(...).Value on the ConcurrentDictionary.
+            lock (httpContext.Items)
+            {
+                if (httpContext.Items.TryGetValue(RequestCacheKey, out var value)
+                    && value is ConcurrentDictionary<string, Lazy<Task<Member>>> cache)
+                {
+                    return cache;
+                }
+
+                cache = new ConcurrentDictionary<string, Lazy<Task<Member>>>();
+                httpContext.Items[RequestCacheKey] = cache;
+
+                return cache;
+            }
         }
 
         private async Task<Member> ResolveMemberByIdInternalAsync(string userId)

--- a/src/VirtoCommerce.CustomerModule.Web/Module.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Module.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using FluentValidation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -85,7 +87,12 @@ namespace VirtoCommerce.CustomerModule.Web
             serviceCollection.AddTransient<IIndexedMemberSearchService, MemberIndexedSearchService>();
             serviceCollection.AddTransient<IMemberSearchService, MemberSearchService>();
             serviceCollection.AddTransient<IMemberService, MemberService>();
-            serviceCollection.AddTransient<IMemberResolver, MemberResolver>();
+            // Explicit factory pins the ctor: the [Obsolete] 3-arg ctor makes reflection-based
+            // constructor selection ambiguous once IHttpContextAccessor is added. Same Transient lifetime.
+            serviceCollection.AddTransient<IMemberResolver>(provider => new MemberResolver(
+                provider.GetRequiredService<IMemberService>(),
+                provider.GetRequiredService<Func<UserManager<ApplicationUser>>>(),
+                provider.GetRequiredService<IHttpContextAccessor>()));
             serviceCollection.AddSingleton<CustomerExportImport>();
             serviceCollection.AddTransient<MemberSearchRequestBuilder>();
             serviceCollection.AddSingleton<IFavoriteAddressService, FavoriteAddressService>();

--- a/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.CustomerModule.Core.Model;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.CustomerModule.Data.Services;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Security;
+using Xunit;
+
+namespace VirtoCommerce.CustomerModule.Tests
+{
+    public class MemberResolverTests
+    {
+        private const string UserId = "user-1";
+        private const string OtherUserId = "user-2";
+
+        [Fact]
+        public async Task ResolveMemberByIdAsync_SameUserIdWithHttpContext_ResolvesUnderlyingOnlyOnce()
+        {
+            //Arrange
+            var memberServiceMock = new Mock<IMemberService>();
+            memberServiceMock.Setup(x => x.GetByIdAsync(It.IsAny<string>(), null, null)).ReturnsAsync((Member)null);
+
+            var factoryCallCount = 0;
+            Func<UserManager<ApplicationUser>> userManagerFactory = () =>
+            {
+                factoryCallCount++;
+                return CreateUserManager();
+            };
+
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+
+            var resolver = new MemberResolver(memberServiceMock.Object, userManagerFactory, httpContextAccessorMock.Object);
+
+            //Act
+            await resolver.ResolveMemberByIdAsync(UserId);
+            await resolver.ResolveMemberByIdAsync(UserId);
+            await resolver.ResolveMemberByIdAsync(UserId);
+
+            //Assert
+            Assert.Equal(1, factoryCallCount);
+        }
+
+        [Fact]
+        public async Task ResolveMemberByIdAsync_NoHttpContext_ResolvesUnderlyingEveryCall()
+        {
+            //Arrange
+            var memberServiceMock = new Mock<IMemberService>();
+            memberServiceMock.Setup(x => x.GetByIdAsync(It.IsAny<string>(), null, null)).ReturnsAsync((Member)null);
+
+            var factoryCallCount = 0;
+            Func<UserManager<ApplicationUser>> userManagerFactory = () =>
+            {
+                factoryCallCount++;
+                return CreateUserManager();
+            };
+
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            httpContextAccessorMock.Setup(x => x.HttpContext).Returns((HttpContext)null);
+
+            var resolver = new MemberResolver(memberServiceMock.Object, userManagerFactory, httpContextAccessorMock.Object);
+
+            //Act
+            await resolver.ResolveMemberByIdAsync(UserId);
+            await resolver.ResolveMemberByIdAsync(UserId);
+            await resolver.ResolveMemberByIdAsync(UserId);
+
+            //Assert
+            Assert.Equal(3, factoryCallCount);
+        }
+
+        [Fact]
+        public async Task ResolveMemberByIdAsync_DistinctUserIds_CachedIndependently()
+        {
+            //Arrange
+            var memberServiceMock = new Mock<IMemberService>();
+            memberServiceMock.Setup(x => x.GetByIdAsync(It.IsAny<string>(), null, null)).ReturnsAsync((Member)null);
+
+            var factoryCallCount = 0;
+            Func<UserManager<ApplicationUser>> userManagerFactory = () =>
+            {
+                factoryCallCount++;
+                return CreateUserManager();
+            };
+
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+
+            var resolver = new MemberResolver(memberServiceMock.Object, userManagerFactory, httpContextAccessorMock.Object);
+
+            //Act
+            await resolver.ResolveMemberByIdAsync(UserId);
+            await resolver.ResolveMemberByIdAsync(UserId);
+            await resolver.ResolveMemberByIdAsync(OtherUserId);
+            await resolver.ResolveMemberByIdAsync(OtherUserId);
+
+            //Assert
+            Assert.Equal(2, factoryCallCount);
+        }
+
+        [Fact]
+        public void ServiceCollection_ResolvesIMemberResolver_MirroringModuleRegistration()
+        {
+            //Arrange
+            var memberServiceMock = new Mock<IMemberService>();
+
+            var services = new ServiceCollection();
+            services.AddSingleton(memberServiceMock.Object);
+            services.AddSingleton<Func<UserManager<ApplicationUser>>>(() => CreateUserManager());
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+            // Mirrors the explicit factory registration in Module.cs, which pins the exact constructor
+            // to avoid ambiguity with the [Obsolete] IPlatformMemoryCache-accepting constructor.
+            services.AddTransient<IMemberResolver>(provider => new MemberResolver(
+                provider.GetRequiredService<IMemberService>(),
+                provider.GetRequiredService<Func<UserManager<ApplicationUser>>>(),
+                provider.GetRequiredService<IHttpContextAccessor>()));
+
+            using var provider = services.BuildServiceProvider(validateScopes: true);
+
+            //Act
+            var resolver = provider.GetRequiredService<IMemberResolver>();
+
+            //Assert
+            Assert.IsType<MemberResolver>(resolver);
+        }
+
+        [Fact]
+        public void ServiceCollection_GenericRegistration_ThrowsAmbiguousConstructor()
+        {
+            //Arrange
+            var memberServiceMock = new Mock<IMemberService>();
+            var platformMemoryCacheMock = new Mock<IPlatformMemoryCache>();
+
+            var services = new ServiceCollection();
+            services.AddSingleton(memberServiceMock.Object);
+            services.AddSingleton<Func<UserManager<ApplicationUser>>>(() => CreateUserManager());
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddSingleton(platformMemoryCacheMock.Object);
+
+            // Pins the premise for the factory registration in Module.cs: with both ctors DI-resolvable,
+            // the generic AddTransient<TService, TImplementation>() overload cannot pick a constructor.
+            services.AddTransient<IMemberResolver, MemberResolver>();
+
+            using var provider = services.BuildServiceProvider(validateScopes: true);
+
+            //Act
+            var exception = Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<IMemberResolver>());
+
+            //Assert
+            Assert.Contains("constructor", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ResolveMemberByIdAsync_MemberServiceReturnsMember_ReturnsSameMemberAndCachesIt()
+        {
+            //Arrange
+            var member = new Contact { Id = "member-1" };
+
+            var memberServiceMock = new Mock<IMemberService>();
+            memberServiceMock.Setup(x => x.GetByIdAsync(UserId, null, null)).ReturnsAsync(member);
+
+            var factoryCallCount = 0;
+            Func<UserManager<ApplicationUser>> userManagerFactory = () =>
+            {
+                factoryCallCount++;
+                return CreateUserManager();
+            };
+
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+
+            var resolver = new MemberResolver(memberServiceMock.Object, userManagerFactory, httpContextAccessorMock.Object);
+
+            //Act
+            var first = await resolver.ResolveMemberByIdAsync(UserId);
+            var second = await resolver.ResolveMemberByIdAsync(UserId);
+
+            //Assert
+            Assert.Same(member, first);
+            Assert.Same(member, second);
+            Assert.Equal(1, factoryCallCount);
+        }
+
+        [Fact]
+        public async Task ResolveMemberByIdAsync_ConcurrentSameUserId_ResolvesOnceAndSharesResult()
+        {
+            //Arrange
+            var member = new Contact { Id = "member-1" };
+
+            var getByIdCallCount = 0;
+            var memberServiceMock = new Mock<IMemberService>();
+            memberServiceMock.Setup(x => x.GetByIdAsync(UserId, null, null))
+                .Returns(async () =>
+                {
+                    Interlocked.Increment(ref getByIdCallCount);
+                    // Yield so concurrent same-key misses are actually exercised.
+                    await Task.Yield();
+                    return member;
+                });
+
+            var httpContext = new DefaultHttpContext();
+            _ = httpContext.Items; // Real requests materialize Items early in the pipeline, before resolvers fan out.
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext);
+
+            var resolver = new MemberResolver(memberServiceMock.Object, CreateUserManager, httpContextAccessorMock.Object);
+
+            //Act
+            var tasks = Enumerable.Range(0, 50).Select(_ => Task.Run(() => resolver.ResolveMemberByIdAsync(UserId)));
+            var results = await Task.WhenAll(tasks);
+
+            //Assert
+            Assert.Equal(1, getByIdCallCount);
+            Assert.All(results, x => Assert.Same(member, x));
+        }
+
+        private static UserManager<ApplicationUser> CreateUserManager()
+        {
+            var storeMock = new Mock<IUserStore<ApplicationUser>>();
+            storeMock.Setup(x => x.FindByIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((ApplicationUser)null);
+
+            var optionsMock = new Mock<IOptions<IdentityOptions>>();
+            optionsMock.Setup(x => x.Value).Returns(new IdentityOptions());
+
+            return new UserManager<ApplicationUser>(
+                storeMock.Object,
+                optionsMock.Object,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+        }
+    }
+}


### PR DESCRIPTION
### Problem

`MemberResolver.ResolveMemberByIdAsync` constructs a fresh `UserManager` on every call (via the singleton `Func<UserManager<ApplicationUser>>` factory, which opens a new DI scope per invocation). Read paths resolve the same authenticated user's member many times per request (price eval, promotion eval, per product-configuration query), so it runs N times per request for one user. On .NET 9 the `UserManager<T>` ctor builds a `UserManagerMetrics` whose ctor registers instruments via `Meter.GetOrCreateInstrument` — a call that takes the meter's instrument-list lock unconditionally. Under concurrency the repeated construction turns that lock into a convoy.

### Measurement

50-VU distinct-mix cart-read load, `dotnet-trace` sampled-thread-time: `Meter.GetOrCreateInstrument` was **45.7% of active CPU**, 100% via `UserManagerMetrics..ctor` on the member-resolution path. After: **~0%** (7 of 1.82M samples = the one legitimate construction per request); total active-CPU share 46.5% -> 31.8%. This is a CPU-efficiency / scalability fix (frees ~1/3 of active CPU, removes redundant per-request `UserManager` construction); not a standalone latency reduction at the tested load — the request latency wall is off-CPU.

### Fix

Per-request cache in `HttpContext.Items`, keyed by userId. Resolver stays `Transient`; a per-request `ConcurrentDictionary<string, Lazy<Task<Member>>>` (container bootstrapped under a lock, since `HttpContext.Items` is not thread-safe) guarantees the resolution runs once per user per request even under concurrent access. No `HttpContext` (background jobs) -> uncached path, unchanged. `Module.cs` switches the registration to an explicit factory to pin the ctor (the pre-existing `[Obsolete]` 3-arg ctor otherwise makes reflection-based selection ambiguous once `IHttpContextAccessor` is added); lifetime stays `Transient`.

A prior cross-request `IPlatformMemoryCache` version was reverted (VCST-4750) for stale members; a per-request cache cannot reproduce that — it lives one request and takes no dependency on invalidation tokens. A faulted resolution is cached for the rest of the request (not retried per-call); acceptable on a read path.

### Tests

7 tests: same-userId resolves once; no-HttpContext resolves each call; distinct userIds independent; happy-path returns the member; 50-way concurrent same-userId resolves once; DI resolves without the ambiguous-constructor throw.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a hot read path used across cart/pricing flows; per-request scope limits staleness risk but failed resolutions are cached for the rest of the request.
> 
> **Overview**
> **Member resolution is deduplicated within a single HTTP request** so repeated `ResolveMemberByIdAsync` calls for the same user no longer spin up a new `UserManager` each time (addressing .NET 9 `UserManagerMetrics` / meter lock convoy under load).
> 
> `MemberResolver` now takes `IHttpContextAccessor` and stores a `ConcurrentDictionary<string, Lazy<Task<Member>>>` in `HttpContext.Items`, with thread-safe container creation and `Lazy` so concurrent callers share one resolution per userId. When there is no ambient `HttpContext` (e.g. background work), behavior stays the uncached path.
> 
> **DI registration** in `Module.cs` switches to an explicit factory that wires the new constructor, because the obsolete `IPlatformMemoryCache` ctor would make generic `AddTransient<IMemberResolver, MemberResolver>()` ambiguous.
> 
> **Tests** cover single-call caching, no-context behavior, distinct userIds, concurrency, happy-path member reuse, and the factory vs ambiguous generic registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9436e373d77c7e2d4aab8daa652773e6c0bfd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5303
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1017.0-pr-307-e943.zip