### PR TITLE
VCST-5496: One blocked organization membership breaking contact authentication fix

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
@@ -34,59 +34,81 @@ public class OrganizationIdRequestValidator(
         // return the global error immediately without checking org-level state.
         if (context.User != null && IsGloballyLocked(context.User))
         {
-            // Distinguish a permanent lock (LockoutEnd == DateTime.MaxValue) from a temporary
-            // failed-attempt lock, mirroring how the platform's BaseUserSignInValidator decides.
-            // Otherwise org members get the permanent-worded code for a self-clearing 15-min lock.
-            var permanentLockOut = context.User.LockoutEnd == DateTime.MaxValue.ToUniversalTime();
-            return [permanentLockOut
-                ? ErrorDescriber.UserIsLockedOut()
-                : SecurityErrorDescriber.UserIsTemporaryLockedOut()];
+            return [GetGlobalLockoutError(context.User)];
         }
 
         var availableOrganizationIds = await GetAvailableOrganizationIds(context);
         if (!availableOrganizationIds.Contains(organizationId))
         {
-            // Replace invalid organization ID with default organization ID when signing in
-            if (context.Request.GrantType == OpenIddictConstants.GrantTypes.Password)
-            {
-                context.Request.SetParameter(Parameters.OrganizationId, availableOrganizationIds.FirstOrDefault());
-                return [];
-            }
-
-            return [ErrorDescriber.InvalidOrganizationId(organizationId)];
+            return HandleUnavailableOrganization(context, organizationId, availableOrganizationIds);
         }
 
         if (context.User != null)
         {
-            var membership = (await organizationMembershipSearchService.SearchAsync(new OrganizationMembershipSearchCriteria
+            var lockError = await ValidateOrganizationLockAsync(context, requestedOrganizationId, organizationId, availableOrganizationIds);
+            if (lockError != null)
             {
-                UserId = context.User.Id,
-                OrganizationId = organizationId,
-                Take = 1,
-            })).Results.FirstOrDefault();
-            if (membership != null && membership.IsCurrentlyLocked)
-            {
-                // When the organization was auto-resolved (the caller didn't request a specific one) on a fresh
-                // password sign-in, a lock in that single organization must not lock the user out of the others
-                // they belong to — e.g. a sales rep serving many organizations. Fall back to a non-locked
-                // organization instead. Block only when the caller explicitly asked for this (now-locked)
-                // organization, or every organization the user belongs to is locked.
-                if (string.IsNullOrEmpty(requestedOrganizationId) &&
-                    context.Request.GrantType == OpenIddictConstants.GrantTypes.Password)
-                {
-                    var unlockedOrganizationId = await GetFirstUnlockedOrganizationId(context.User.Id, availableOrganizationIds);
-                    if (!string.IsNullOrEmpty(unlockedOrganizationId))
-                    {
-                        context.Request.SetParameter(Parameters.OrganizationId, unlockedOrganizationId);
-                        return [];
-                    }
-                }
-
-                return [ErrorDescriber.UserIsLockedInOrganization(organizationId)];
+                return [lockError];
             }
         }
 
         return [];
+    }
+
+    private static TokenResponse GetGlobalLockoutError(ApplicationUser user)
+    {
+        // Distinguish a permanent lock (LockoutEnd == DateTime.MaxValue) from a temporary failed-attempt lock,
+        // mirroring how the platform's BaseUserSignInValidator decides. Otherwise org members get the
+        // permanent-worded code for a self-clearing 15-min lock.
+        var permanentLockOut = user.LockoutEnd == DateTime.MaxValue.ToUniversalTime();
+        return permanentLockOut
+            ? ErrorDescriber.UserIsLockedOut()
+            : SecurityErrorDescriber.UserIsTemporaryLockedOut();
+    }
+
+    private static IList<TokenResponse> HandleUnavailableOrganization(TokenRequestContext context, string organizationId, IList<string> availableOrganizationIds)
+    {
+        // Replace an invalid organization ID with the default organization ID when signing in.
+        if (context.Request.GrantType == OpenIddictConstants.GrantTypes.Password)
+        {
+            context.Request.SetParameter(Parameters.OrganizationId, availableOrganizationIds.FirstOrDefault());
+            return [];
+        }
+
+        return [ErrorDescriber.InvalidOrganizationId(organizationId)];
+    }
+
+    private async Task<TokenResponse> ValidateOrganizationLockAsync(TokenRequestContext context, string requestedOrganizationId, string organizationId, IList<string> availableOrganizationIds)
+    {
+        var membership = (await organizationMembershipSearchService.SearchAsync(new OrganizationMembershipSearchCriteria
+        {
+            UserId = context.User.Id,
+            OrganizationId = organizationId,
+            Take = 1,
+        })).Results.FirstOrDefault();
+
+        if (membership is null || !membership.IsCurrentlyLocked)
+        {
+            return null;
+        }
+
+        // When the organization was auto-resolved (the caller didn't request a specific one) on a fresh password
+        // sign-in, a lock in that single organization must not lock the user out of the others they belong to —
+        // e.g. a sales rep serving many organizations. Fall back to a non-locked organization instead. Block only
+        // when the caller explicitly asked for this (now-locked) organization, or every organization is locked.
+        var isAutoResolved = string.IsNullOrEmpty(requestedOrganizationId) &&
+            context.Request.GrantType == OpenIddictConstants.GrantTypes.Password;
+        if (isAutoResolved)
+        {
+            var unlockedOrganizationId = await GetFirstUnlockedOrganizationId(context.User.Id, availableOrganizationIds);
+            if (!string.IsNullOrEmpty(unlockedOrganizationId))
+            {
+                context.Request.SetParameter(Parameters.OrganizationId, unlockedOrganizationId);
+                return null;
+            }
+        }
+
+        return ErrorDescriber.UserIsLockedInOrganization(organizationId);
     }
 
     private async Task<string> GetFirstUnlockedOrganizationId(string userId, IList<string> availableOrganizationIds)

--- a/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
@@ -21,6 +21,9 @@ public class OrganizationIdRequestValidator(
 
     public virtual async Task<IList<TokenResponse>> ValidateAsync(TokenRequestContext context)
     {
+        // Captured before any fallback below rewrites the parameter, so an explicit request for a specific
+        // organization can be told apart from one auto-resolved from the member.
+        var requestedOrganizationId = context.Request.GetParameter(Parameters.OrganizationId)?.ToString();
         var organizationId = await GetOrganizationId(context);
         if (string.IsNullOrEmpty(organizationId))
         {
@@ -63,11 +66,35 @@ public class OrganizationIdRequestValidator(
             })).Results.FirstOrDefault();
             if (membership != null && membership.IsCurrentlyLocked)
             {
+                // When the organization was auto-resolved (the caller didn't request a specific one) on a fresh
+                // password sign-in, a lock in that single organization must not lock the user out of the others
+                // they belong to — e.g. a sales rep serving many organizations. Fall back to a non-locked
+                // organization instead. Block only when the caller explicitly asked for this (now-locked)
+                // organization, or every organization the user belongs to is locked.
+                if (string.IsNullOrEmpty(requestedOrganizationId) &&
+                    context.Request.GrantType == OpenIddictConstants.GrantTypes.Password)
+                {
+                    var unlockedOrganizationId = await GetFirstUnlockedOrganizationId(context.User.Id, availableOrganizationIds);
+                    if (!string.IsNullOrEmpty(unlockedOrganizationId))
+                    {
+                        context.Request.SetParameter(Parameters.OrganizationId, unlockedOrganizationId);
+                        return [];
+                    }
+                }
+
                 return [ErrorDescriber.UserIsLockedInOrganization(organizationId)];
             }
         }
 
         return [];
+    }
+
+    private async Task<string> GetFirstUnlockedOrganizationId(string userId, IList<string> availableOrganizationIds)
+    {
+        var lockedOrganizationIds = (await organizationMembershipSearchService.GetLockedOrganizationIdsAsync(userId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return availableOrganizationIds.FirstOrDefault(id => !lockedOrganizationIds.Contains(id));
     }
 
     /// <summary>

--- a/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
@@ -21,9 +21,11 @@ public class OrganizationIdRequestValidator(
 
     public virtual async Task<IList<TokenResponse>> ValidateAsync(TokenRequestContext context)
     {
-        // Captured before any fallback below rewrites the parameter, so an explicit request for a specific
-        // organization can be told apart from one auto-resolved from the member.
-        var requestedOrganizationId = context.Request.GetParameter(Parameters.OrganizationId)?.ToString();
+        // Whether the organization was auto-resolved from the member (no explicit request) on a fresh password
+        // sign-in — computed before any fallback below rewrites the parameter. Only then may a locked auto-resolved
+        // organization fall back to a non-locked one instead of blocking.
+        var isAutoResolved = string.IsNullOrEmpty(context.Request.GetParameter(Parameters.OrganizationId)?.ToString()) &&
+            context.Request.GrantType == OpenIddictConstants.GrantTypes.Password;
         var organizationId = await GetOrganizationId(context);
         if (string.IsNullOrEmpty(organizationId))
         {
@@ -45,7 +47,7 @@ public class OrganizationIdRequestValidator(
 
         if (context.User != null)
         {
-            var lockError = await ValidateOrganizationLockAsync(context, requestedOrganizationId, organizationId, availableOrganizationIds);
+            var lockError = await ValidateOrganizationLockAsync(context, isAutoResolved, organizationId, availableOrganizationIds);
             if (lockError != null)
             {
                 return [lockError];
@@ -78,15 +80,9 @@ public class OrganizationIdRequestValidator(
         return [ErrorDescriber.InvalidOrganizationId(organizationId)];
     }
 
-    private async Task<TokenResponse> ValidateOrganizationLockAsync(TokenRequestContext context, string requestedOrganizationId, string organizationId, IList<string> availableOrganizationIds)
+    private async Task<TokenResponse> ValidateOrganizationLockAsync(TokenRequestContext context, bool isAutoResolved, string organizationId, IList<string> availableOrganizationIds)
     {
-        var membership = (await organizationMembershipSearchService.SearchAsync(new OrganizationMembershipSearchCriteria
-        {
-            UserId = context.User.Id,
-            OrganizationId = organizationId,
-            Take = 1,
-        })).Results.FirstOrDefault();
-
+        var membership = await GetMembership(context.User.Id, organizationId);
         if (membership is null || !membership.IsCurrentlyLocked)
         {
             return null;
@@ -96,8 +92,6 @@ public class OrganizationIdRequestValidator(
         // sign-in, a lock in that single organization must not lock the user out of the others they belong to —
         // e.g. a sales rep serving many organizations. Fall back to a non-locked organization instead. Block only
         // when the caller explicitly asked for this (now-locked) organization, or every organization is locked.
-        var isAutoResolved = string.IsNullOrEmpty(requestedOrganizationId) &&
-            context.Request.GrantType == OpenIddictConstants.GrantTypes.Password;
         if (isAutoResolved)
         {
             var unlockedOrganizationId = await GetFirstUnlockedOrganizationId(context.User.Id, availableOrganizationIds);
@@ -109,6 +103,18 @@ public class OrganizationIdRequestValidator(
         }
 
         return ErrorDescriber.UserIsLockedInOrganization(organizationId);
+    }
+
+    private async Task<OrganizationMembership> GetMembership(string userId, string organizationId)
+    {
+        var result = await organizationMembershipSearchService.SearchAsync(new OrganizationMembershipSearchCriteria
+        {
+            UserId = userId,
+            OrganizationId = organizationId,
+            Take = 1,
+        });
+
+        return result.Results.FirstOrDefault();
     }
 
     private async Task<string> GetFirstUnlockedOrganizationId(string userId, IList<string> availableOrganizationIds)

--- a/tests/VirtoCommerce.CustomerModule.Tests/OrganizationIdRequestValidatorTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/OrganizationIdRequestValidatorTests.cs
@@ -231,6 +231,95 @@ public class OrganizationIdRequestValidatorTests
         Assert.Equal(OrgId, context.Request.GetParameter(Parameters.OrganizationId)?.ToString());
     }
 
+    [Fact]
+    public async Task ValidateAsync_PasswordGrant_AutoResolvedOrgLocked_FallsBackToUnlockedOrg_ReturnsEmpty()
+    {
+        //Arrange — a rep serves two orgs; the auto-resolved (first) one is locked, the other is active. A fresh
+        // password sign-in must NOT be blocked: locking one org must not lock the rep out of the others.
+        const string lockedOrg = "org-locked";
+        const string activeOrg = "org-active";
+
+        var user = new ApplicationUser { Id = UserId, MemberId = MemberId };
+        _memberServiceMock.Setup(s => s.GetByIdAsync(MemberId, null, null))
+            .ReturnsAsync(new Contact { Id = MemberId, Organizations = [lockedOrg, activeOrg] });
+
+        _membershipServiceMock
+            .Setup(s => s.SearchAsync(
+                It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == lockedOrg),
+                It.IsAny<bool>()))
+            .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [new OrganizationMembership { IsLocked = true }] });
+        _membershipServiceMock
+            .Setup(s => s.GetLockedOrganizationIdsAsync(UserId))
+            .ReturnsAsync(new[] { lockedOrg });
+
+        var context = BuildContext(orgId: null, grantType: OpenIddictConstants.GrantTypes.Password, user: user);
+
+        //Act
+        var result = await GetValidator().ValidateAsync(context);
+
+        //Assert — no error, and the request switched to the active org.
+        Assert.Empty(result);
+        Assert.Equal(activeOrg, context.Request.GetParameter(Parameters.OrganizationId)?.ToString());
+    }
+
+    [Fact]
+    public async Task ValidateAsync_PasswordGrant_AllOrgsLocked_ReturnsOrgError()
+    {
+        //Arrange — every org the rep belongs to is locked: nowhere to fall back to, so sign-in is blocked.
+        const string lockedOrg1 = "org-locked-1";
+        const string lockedOrg2 = "org-locked-2";
+
+        var user = new ApplicationUser { Id = UserId, MemberId = MemberId };
+        _memberServiceMock.Setup(s => s.GetByIdAsync(MemberId, null, null))
+            .ReturnsAsync(new Contact { Id = MemberId, Organizations = [lockedOrg1, lockedOrg2] });
+
+        _membershipServiceMock
+            .Setup(s => s.SearchAsync(
+                It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == lockedOrg1),
+                It.IsAny<bool>()))
+            .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [new OrganizationMembership { IsLocked = true }] });
+        _membershipServiceMock
+            .Setup(s => s.GetLockedOrganizationIdsAsync(UserId))
+            .ReturnsAsync(new[] { lockedOrg1, lockedOrg2 });
+
+        var context = BuildContext(orgId: null, grantType: OpenIddictConstants.GrantTypes.Password, user: user);
+
+        //Act
+        var result = await GetValidator().ValidateAsync(context);
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, result[0].Error);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_PasswordGrant_ExplicitlyRequestedLockedOrg_ReturnsOrgError()
+    {
+        //Arrange — the caller explicitly asks to sign in as a specific (locked) org. That is an explicit choice,
+        // so it must be blocked rather than silently falling back to another org.
+        const string lockedOrg = "org-locked";
+        const string activeOrg = "org-active";
+
+        var user = new ApplicationUser { Id = UserId, MemberId = MemberId };
+        _memberServiceMock.Setup(s => s.GetByIdAsync(MemberId, null, null))
+            .ReturnsAsync(new Contact { Id = MemberId, Organizations = [lockedOrg, activeOrg] });
+
+        _membershipServiceMock
+            .Setup(s => s.SearchAsync(
+                It.Is<OrganizationMembershipSearchCriteria>(c => c.UserId == UserId && c.OrganizationId == lockedOrg),
+                It.IsAny<bool>()))
+            .ReturnsAsync(new OrganizationMembershipSearchResult { Results = [new OrganizationMembership { IsLocked = true }] });
+
+        var context = BuildContext(lockedOrg, grantType: OpenIddictConstants.GrantTypes.Password, user: user);
+
+        //Act
+        var result = await GetValidator().ValidateAsync(context);
+
+        //Assert
+        Assert.Single(result);
+        Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, result[0].Error);
+    }
+
     private void SetupMembership(OrganizationMembership membership) =>
         _membershipServiceMock
             .Setup(s => s.SearchAsync(


### PR DESCRIPTION
## Description
A contact whose membership in ONE org is locked cannot obtain a security token at all (HTTP 400 invalid_grant, on any store).

**Root cause** — `OrganizationIdRequestValidator` (customer module): on a token request with no explicit `organizationId`, it auto-resolves one org from the contact (`CurrentOrganizationId` → `DefaultOrganizationId` → `Organizations.First()`) and rejects sign-in if that org's membership is locked — ignoring the user's other active orgs. A contact's first-listed org being locked therefore blocks authentication entirely.

**Fix** — `OrganizationIdRequestValidator`: when the locked org was auto-resolved (not explicitly requested) on a password grant, fall back to a non-locked org the user belongs to (via `GetLockedOrganizationIdsAsync`), mirroring the existing "invalid org → replace with available" pattern. Block only when the caller explicitly asked for the locked org, or all their orgs are locked.

**Tests** `OrganizationIdRequestValidatorTests`: auto-resolved-locked → falls back to active org (empty result, org param switched); all-orgs-locked → blocked; explicitly-requested-locked → blocked. Existing tests unchanged/green.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5496
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1016.0-pr-308-525d.zip