### PR TITLE
fix(VCST-5497): add time zone to created/modified date range filter tokens

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Web/Scripts/blades/member-list.js
+++ b/src/VirtoCommerce.CustomerModule.Web/Scripts/blades/member-list.js
@@ -375,7 +375,7 @@ angular.module('virtoCommerce.customerModule')
                 var m = `0${dt.getMonth() + 1}`.slice(-2);
                 var day = `0${dt.getDate()}`.slice(-2);
 
-                return endOfTheDay ? `"${y}-${m}-${day}T23:59:59"` : `"${y}-${m}-${day}T00:00:00"`;
+                return endOfTheDay ? `"${y}-${m}-${day}T23:59:59Z"` : `"${y}-${m}-${day}T00:00:00Z"`;
             };
 
             filter.formatDate = function (d) {


### PR DESCRIPTION
## Summary
Fixes **VCST-5497**. Filtering Contacts (Admin SPA) by **Created/Modified Date → Custom range → Apply** returned a 500 **only on the Azure AI Search provider**. This appends a UTC time zone to the date-range filter tokens so the OData literal is valid on every search provider. Boundary times (00:00:00 start / 23:59:59 end) are unchanged.

## Root cause
The member list built the OData `$filter` `DateTimeOffset` literal **without a time zone** (e.g. `createddate:["2026-07-15T00:00:00" TO "2026-07-15T23:59:59"]`). Azure Cognitive Search's OData grammar **requires** a time zone (`Z` or `±hh:mm`) on every `DateTimeOffset` constant, so it returned **400 Bad Request** (surfaced as a **500** in the UI). Elasticsearch/Lucene tolerate the TZ-less literal (return 200), which is why the bug reproduced **only on Azure**.

## Fix
One line in the **provider-agnostic module layer** (not the Azure provider), `src/VirtoCommerce.CustomerModule.Web/Scripts/blades/member-list.js`, function `formatDateForRangeToken` — append a UTC `Z`:
```diff
- return endOfTheDay ? `"${y}-${m}-${day}T23:59:59"` : `"${y}-${m}-${day}T00:00:00"`;
+ return endOfTheDay ? `"${y}-${m}-${day}T23:59:59Z"` : `"${y}-${m}-${day}T00:00:00Z"`;
```
`formatDateForRangeToken` is the single token-builder for both the preset and custom-range paths (start and end), so this covers both uniformly. Created/Modified dates are stored in UTC, so `Z` is semantically correct.

## Test (red → green)
The module has **no in-repo JS test harness**, so per the `/angular-admin` skill an **uncommitted Node scratch harness** extracted the real `formatDateForRangeToken` from source and asserted the tokens against Azure's OData `DateTimeOffset` grammar (`/T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})"$/`):

**RED (before fix):**
```
start token: "2026-07-15T00:00:00"
end   token: "2026-07-15T23:59:59"
PASS: start keeps 00:00:00
PASS: end keeps 23:59:59
FAIL: start is a valid Azure DateTimeOffset (has TZ)
FAIL: end is a valid Azure DateTimeOffset (has TZ)
RESULT: RED (2 failing)
```
**GREEN (after fix):**
```
start token: "2026-07-15T00:00:00Z"
end   token: "2026-07-15T23:59:59Z"
PASS: start keeps 00:00:00
PASS: end keeps 23:59:59
PASS: start is a valid Azure DateTimeOffset (has TZ)
PASS: end is a valid Azure DateTimeOffset (has TZ)
RESULT: GREEN (all pass)
```

## ⚠ Needs deploy verification (Azure Search env)
Statically proven only (the harness validates the literal format). The live 500 from VCST-5497 must be re-confirmed after this module is built and deployed to a QA instance **backed by the Azure AI Search provider** (regression pipeline + `/qa-verify-fix VCST-5497`).

## Reviewer notes
Minimal one-line, provider-agnostic change; no REST/GraphQL/DTO/schema/manifest change; no existing tests modified; BL-* preserved.

> 🤖 Opened by the QA auto-fix pipeline. **DO NOT MERGE until human review + deploy verification.**
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5497
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1015.0-pr-309-0000.zip