### PR TITLE
VCST-5556: reuse platform IRequestScopedCache in MemberResolver

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
+++ b/src/VirtoCommerce.CustomerModule.Core/VirtoCommerce.CustomerModule.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
     <PackageReference Include="VirtoCommerce.NotificationsModule.Core" Version="3.1009.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1048.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />

--- a/src/VirtoCommerce.CustomerModule.Data.MySql/VirtoCommerce.CustomerModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data.MySql/VirtoCommerce.CustomerModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1048.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Data\VirtoCommerce.CustomerModule.Data.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Data.PostgreSql/VirtoCommerce.CustomerModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data.PostgreSql/VirtoCommerce.CustomerModule.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1048.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Data\VirtoCommerce.CustomerModule.Data.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Data.SqlServer/VirtoCommerce.CustomerModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data.SqlServer/VirtoCommerce.CustomerModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1048.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Data\VirtoCommerce.CustomerModule.Data.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Data/Services/MemberResolver.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/MemberResolver.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.Platform.Core.Caching;
@@ -12,8 +12,6 @@ namespace VirtoCommerce.CustomerModule.Data.Services
 {
     public class MemberResolver(IMemberService memberService, Func<UserManager<ApplicationUser>> userManagerFactory, IHttpContextAccessor httpContextAccessor) : IMemberResolver
     {
-        private const string RequestCacheKey = "MemberResolver:RequestCache";
-
         [Obsolete("Use new constructor without IPlatformMemoryCache argument", DiagnosticId = "VC0012", UrlFormat = "https://docs.virtocommerce.org/platform/user-guide/versions/virto3-products-versions/")]
         public MemberResolver(IMemberService memberService, Func<UserManager<ApplicationUser>> userManagerFactory, IPlatformMemoryCache platformMemoryCache)
             : this(memberService, userManagerFactory, (IHttpContextAccessor)null)
@@ -30,38 +28,16 @@ namespace VirtoCommerce.CustomerModule.Data.Services
             // Per-request cache: getFullCart resolves the same shopper's userId many times per request,
             // and each uncached call constructs a fresh CustomUserManager, which takes a process-global
             // Meter lock unconditionally (.NET 9 UserManagerMetrics) -> lock convoy under load.
-            var httpContext = httpContextAccessor?.HttpContext;
-            if (httpContext is null)
+            // Resolved per-call from the request scope (not ctor-injected): keeps this transient service
+            // free of a captured Scoped dependency, so singleton consumers of IMemberResolver stay valid.
+            var requestCache = httpContextAccessor?.HttpContext?.RequestServices?.GetService<IRequestScopedCache>();
+            if (requestCache is null)
             {
-                // No ambient request (e.g. background job) - nothing to scope the cache to.
+                // No ambient request scope (e.g. background job) - nothing to scope the cache to.
                 return ResolveMemberByIdInternalAsync(userId);
             }
 
-            var cache = GetOrCreateRequestCache(httpContext);
-
-            // Lazy guarantees the resolution runs once even if two callers miss the same key concurrently.
-            var lazyTask = cache.GetOrAdd(userId, static (id, resolver) => new Lazy<Task<Member>>(() => resolver.ResolveMemberByIdInternalAsync(id)), this);
-
-            return lazyTask.Value;
-        }
-
-        private static ConcurrentDictionary<string, Lazy<Task<Member>>> GetOrCreateRequestCache(HttpContext httpContext)
-        {
-            // HttpContext.Items is not thread-safe; the O(1) container get-or-create runs under the lock.
-            // The expensive resolution stays outside it, via GetOrAdd(...).Value on the ConcurrentDictionary.
-            lock (httpContext.Items)
-            {
-                if (httpContext.Items.TryGetValue(RequestCacheKey, out var value)
-                    && value is ConcurrentDictionary<string, Lazy<Task<Member>>> cache)
-                {
-                    return cache;
-                }
-
-                cache = new ConcurrentDictionary<string, Lazy<Task<Member>>>();
-                httpContext.Items[RequestCacheKey] = cache;
-
-                return cache;
-            }
+            return requestCache.GetOrAddAsync($"{nameof(MemberResolver)}:{userId}", () => ResolveMemberByIdInternalAsync(userId));
         }
 
         private async Task<Member> ResolveMemberByIdInternalAsync(string userId)

--- a/src/VirtoCommerce.CustomerModule.Data/VirtoCommerce.CustomerModule.Data.csproj
+++ b/src/VirtoCommerce.CustomerModule.Data/VirtoCommerce.CustomerModule.Data.csproj
@@ -9,9 +9,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1048.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1048.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1048.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CustomerModule.Core\VirtoCommerce.CustomerModule.Core.csproj" />

--- a/src/VirtoCommerce.CustomerModule.Web/module.manifest
+++ b/src/VirtoCommerce.CustomerModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1020.0</version>
   <version-tag />
 
-  <platformVersion>3.1039.0</platformVersion>
+  <platformVersion>3.1048.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Core" version="3.1007.0" />
     <dependency id="VirtoCommerce.Notifications" version="3.1009.0" />

--- a/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +24,7 @@ namespace VirtoCommerce.CustomerModule.Tests
         private const string OtherUserId = "user-2";
 
         [Fact]
-        public async Task ResolveMemberByIdAsync_SameUserIdWithHttpContext_ResolvesUnderlyingOnlyOnce()
+        public async Task ResolveMemberByIdAsync_SameUserIdWithRequestCache_ResolvesUnderlyingOnlyOnce()
         {
             //Arrange
             var memberServiceMock = new Mock<IMemberService>();
@@ -35,8 +37,7 @@ namespace VirtoCommerce.CustomerModule.Tests
                 return CreateUserManager();
             };
 
-            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+            var httpContextAccessorMock = CreateHttpContextAccessorWithCache();
 
             var resolver = new MemberResolver(memberServiceMock.Object, userManagerFactory, httpContextAccessorMock.Object);
 
@@ -50,7 +51,7 @@ namespace VirtoCommerce.CustomerModule.Tests
         }
 
         [Fact]
-        public async Task ResolveMemberByIdAsync_NoHttpContext_ResolvesUnderlyingEveryCall()
+        public async Task ResolveMemberByIdAsync_NoRequestScope_ResolvesUnderlyingEveryCall()
         {
             //Arrange
             var memberServiceMock = new Mock<IMemberService>();
@@ -91,8 +92,7 @@ namespace VirtoCommerce.CustomerModule.Tests
                 return CreateUserManager();
             };
 
-            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+            var httpContextAccessorMock = CreateHttpContextAccessorWithCache();
 
             var resolver = new MemberResolver(memberServiceMock.Object, userManagerFactory, httpContextAccessorMock.Object);
 
@@ -175,8 +175,7 @@ namespace VirtoCommerce.CustomerModule.Tests
                 return CreateUserManager();
             };
 
-            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(new DefaultHttpContext());
+            var httpContextAccessorMock = CreateHttpContextAccessorWithCache();
 
             var resolver = new MemberResolver(memberServiceMock.Object, userManagerFactory, httpContextAccessorMock.Object);
 
@@ -207,10 +206,7 @@ namespace VirtoCommerce.CustomerModule.Tests
                     return member;
                 });
 
-            var httpContext = new DefaultHttpContext();
-            _ = httpContext.Items; // Real requests materialize Items early in the pipeline, before resolvers fan out.
-            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-            httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext);
+            var httpContextAccessorMock = CreateHttpContextAccessorWithCache();
 
             var resolver = new MemberResolver(memberServiceMock.Object, CreateUserManager, httpContextAccessorMock.Object);
 
@@ -221,6 +217,20 @@ namespace VirtoCommerce.CustomerModule.Tests
             //Assert
             Assert.Equal(1, getByIdCallCount);
             Assert.All(results, x => Assert.Same(member, x));
+        }
+
+        // Builds an IHttpContextAccessor whose request scope exposes a real single-flight IRequestScopedCache,
+        // mirroring how MemberResolver obtains the cache in production (HttpContext.RequestServices).
+        private static Mock<IHttpContextAccessor> CreateHttpContextAccessorWithCache()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IRequestScopedCache>(new TestRequestScopedCache());
+            var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+
+            var accessorMock = new Mock<IHttpContextAccessor>();
+            accessorMock.Setup(x => x.HttpContext).Returns(httpContext);
+
+            return accessorMock;
         }
 
         private static UserManager<ApplicationUser> CreateUserManager()
@@ -241,6 +251,27 @@ namespace VirtoCommerce.CustomerModule.Tests
                 null,
                 null,
                 null);
+        }
+
+        // Minimal single-flight IRequestScopedCache for tests: same key -> factory runs once (Lazy),
+        // matching the platform RequestScopedCache contract. GetOrLoadMapByIdsAsync is unused by MemberResolver.
+        private sealed class TestRequestScopedCache : IRequestScopedCache
+        {
+            private readonly ConcurrentDictionary<string, Lazy<Task>> _cache = new();
+
+            public Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
+            {
+                var lazy = _cache.GetOrAdd(key, static (_, arg) => new Lazy<Task>(arg), factory);
+
+                return (Task<T>)lazy.Value;
+            }
+
+            public Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
+                string keyPrefix,
+                ICollection<string> ids,
+                Func<T, string> idSelector,
+                Func<ICollection<string>, Task<IList<T>>> loadMissing)
+                where T : class => throw new NotSupportedException();
         }
     }
 }

--- a/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +10,7 @@ using Moq;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.CustomerModule.Data.Services;
+using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Security;
 using Xunit;
@@ -219,13 +218,14 @@ namespace VirtoCommerce.CustomerModule.Tests
             Assert.All(results, x => Assert.Same(member, x));
         }
 
-        // Builds an IHttpContextAccessor whose request scope exposes a real single-flight IRequestScopedCache,
+        // Builds an IHttpContextAccessor whose request scope exposes the real platform RequestScopedCache,
         // mirroring how MemberResolver obtains the cache in production (HttpContext.RequestServices).
         private static Mock<IHttpContextAccessor> CreateHttpContextAccessorWithCache()
         {
             var services = new ServiceCollection();
-            services.AddSingleton<IRequestScopedCache>(new TestRequestScopedCache());
-            var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+            services.AddScoped<IRequestScopedCache, RequestScopedCache>();
+            var scope = services.BuildServiceProvider().CreateScope();
+            var httpContext = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
 
             var accessorMock = new Mock<IHttpContextAccessor>();
             accessorMock.Setup(x => x.HttpContext).Returns(httpContext);
@@ -251,27 +251,6 @@ namespace VirtoCommerce.CustomerModule.Tests
                 null,
                 null,
                 null);
-        }
-
-        // Minimal single-flight IRequestScopedCache for tests: same key -> factory runs once (Lazy),
-        // matching the platform RequestScopedCache contract. GetOrLoadMapByIdsAsync is unused by MemberResolver.
-        private sealed class TestRequestScopedCache : IRequestScopedCache
-        {
-            private readonly ConcurrentDictionary<string, Lazy<Task>> _cache = new();
-
-            public Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
-            {
-                var lazy = _cache.GetOrAdd(key, static (_, arg) => new Lazy<Task>(arg), factory);
-
-                return (Task<T>)lazy.Value;
-            }
-
-            public Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
-                string keyPrefix,
-                ICollection<string> ids,
-                Func<T, string> idSelector,
-                Func<ICollection<string>, Task<IList<T>>> loadMissing)
-                where T : class => throw new NotSupportedException();
         }
     }
 }

--- a/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,12 +17,10 @@ using Xunit;
 
 namespace VirtoCommerce.CustomerModule.Tests
 {
-    public class MemberResolverTests : IDisposable
+    public class MemberResolverTests
     {
         private const string UserId = "user-1";
         private const string OtherUserId = "user-2";
-
-        private readonly List<IDisposable> _disposables = [];
 
         [Fact]
         public async Task ResolveMemberByIdAsync_SameUserIdWithRequestCache_ResolvesUnderlyingOnlyOnce()
@@ -223,29 +220,19 @@ namespace VirtoCommerce.CustomerModule.Tests
 
         // Builds an IHttpContextAccessor whose request scope exposes the real platform RequestScopedCache,
         // mirroring how MemberResolver obtains the cache in production (HttpContext.RequestServices).
-        private Mock<IHttpContextAccessor> CreateHttpContextAccessorWithCache()
+        private static Mock<IHttpContextAccessor> CreateHttpContextAccessorWithCache()
         {
-            var services = new ServiceCollection();
-            services.AddScoped<IRequestScopedCache, RequestScopedCache>();
-            var serviceProvider = services.BuildServiceProvider();
-            var scope = serviceProvider.CreateScope();
-            _disposables.Add(scope);
-            _disposables.Add(serviceProvider);
-
-            var httpContext = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+            // Real platform cache instance (a plain object - nothing to dispose), handed to MemberResolver
+            // through the request scope exactly as in production (HttpContext.RequestServices).
+            var cache = new RequestScopedCache();
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            serviceProviderMock.Setup(x => x.GetService(typeof(IRequestScopedCache))).Returns(cache);
+            var httpContext = new DefaultHttpContext { RequestServices = serviceProviderMock.Object };
 
             var accessorMock = new Mock<IHttpContextAccessor>();
             accessorMock.Setup(x => x.HttpContext).Returns(httpContext);
 
             return accessorMock;
-        }
-
-        public void Dispose()
-        {
-            foreach (var disposable in _disposables)
-            {
-                disposable.Dispose();
-            }
         }
 
         private static UserManager<ApplicationUser> CreateUserManager()

--- a/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/MemberResolverTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,10 +18,12 @@ using Xunit;
 
 namespace VirtoCommerce.CustomerModule.Tests
 {
-    public class MemberResolverTests
+    public class MemberResolverTests : IDisposable
     {
         private const string UserId = "user-1";
         private const string OtherUserId = "user-2";
+
+        private readonly List<IDisposable> _disposables = [];
 
         [Fact]
         public async Task ResolveMemberByIdAsync_SameUserIdWithRequestCache_ResolvesUnderlyingOnlyOnce()
@@ -220,17 +223,29 @@ namespace VirtoCommerce.CustomerModule.Tests
 
         // Builds an IHttpContextAccessor whose request scope exposes the real platform RequestScopedCache,
         // mirroring how MemberResolver obtains the cache in production (HttpContext.RequestServices).
-        private static Mock<IHttpContextAccessor> CreateHttpContextAccessorWithCache()
+        private Mock<IHttpContextAccessor> CreateHttpContextAccessorWithCache()
         {
             var services = new ServiceCollection();
             services.AddScoped<IRequestScopedCache, RequestScopedCache>();
-            var scope = services.BuildServiceProvider().CreateScope();
+            var serviceProvider = services.BuildServiceProvider();
+            var scope = serviceProvider.CreateScope();
+            _disposables.Add(scope);
+            _disposables.Add(serviceProvider);
+
             var httpContext = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
 
             var accessorMock = new Mock<IHttpContextAccessor>();
             accessorMock.Setup(x => x.HttpContext).Returns(httpContext);
 
             return accessorMock;
+        }
+
+        public void Dispose()
+        {
+            foreach (var disposable in _disposables)
+            {
+                disposable.Dispose();
+            }
         }
 
         private static UserManager<ApplicationUser> CreateUserManager()

--- a/tests/VirtoCommerce.CustomerModule.Tests/VirtoCommerce.CustomerModule.Tests.csproj
+++ b/tests/VirtoCommerce.CustomerModule.Tests/VirtoCommerce.CustomerModule.Tests.csproj
@@ -10,6 +10,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="VirtoCommerce.Platform.Caching" Version="3.1048.0" />
     
     
     <PackageReference Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
Replaces the bespoke per-request cache in `MemberResolver` (a custom `ConcurrentDictionary<string, Lazy<Task<Member>>>` stored in `HttpContext.Items`) with the platform primitive `IRequestScopedCache` (`VirtoCommerce.Platform.Core.Caching`).

The cache is resolved **per-call from `HttpContext.RequestServices`** (not constructor-injected), so the Transient `MemberResolver` never captures the Scoped cache — keeping the singleton consumers of `IMemberResolver` (GraphQL schema builders, pipeline middlewares resolved from the root provider) valid. HTTP-context-only caching with a graceful uncached fallback when there is no request scope — same coverage as before.

Bumps the module platform dependency 3.1039.0 → 3.1048.0 (all `VirtoCommerce.Platform.*` packages + `platformVersion` in lockstep; `IRequestScopedCache` shipped in platform 3.1048.0).

Removes ~38 lines of hand-rolled cache machinery. Tests reworked to route caching through `HttpContext.RequestServices`; 146/146 pass.

Related: VCST-5303 (where the custom cache was first added).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path member resolution and requires platform 3.1048+; caching semantics now depend on platform `IRequestScopedCache` registration in HTTP requests.
> 
> **Overview**
> **MemberResolver** no longer keeps a custom per-request cache in `HttpContext.Items`; it uses the platform **`IRequestScopedCache`** via `HttpContext.RequestServices` on each call so the transient resolver does not hold a scoped dependency (singleton consumers of `IMemberResolver` remain valid). When there is no request scope, behavior is unchanged: every call resolves without caching.
> 
> **Platform alignment:** all `VirtoCommerce.Platform.*` package references and `module.manifest` **`platformVersion`** move **3.1039.0 → 3.1048.0** (needed for `IRequestScopedCache`). Tests wire the real `RequestScopedCache` through mocked `RequestServices` and add a **`VirtoCommerce.Platform.Caching`** test dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ceaba40c9c3fbaac13c916f931ea8a0eb631aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5556
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1020.0-pr-311-9cea.zip