### PR TITLE
VCST-5450: Made company member roles configurable per store

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CustomerModule.Core/ModuleConstants.cs
@@ -209,7 +209,7 @@ namespace VirtoCommerce.CustomerModule.Core
                 }
             }
 
-            public static IEnumerable<SettingDescriptor> AllSettings => General.AllSettings;
+            public static IEnumerable<SettingDescriptor> AllModuleSettings => General.AllSettings;
         }
     }
 }

--- a/src/VirtoCommerce.CustomerModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CustomerModule.Core/ModuleConstants.cs
@@ -20,7 +20,7 @@ namespace VirtoCommerce.CustomerModule.Core
                 public const string Delete = "customer:delete";
                 public const string Invite = "customer:invite";
 
-                public static string[] AllPermissions { get; } = { Read, Create, Access, Update, Delete, Invite };
+                public static string[] AllPermissions { get; } = [Read, Create, Access, Update, Delete, Invite];
             }
 
             public static class OrganizationMembershipPermissions
@@ -30,7 +30,7 @@ namespace VirtoCommerce.CustomerModule.Core
                 public const string Update = "customer:organization-membership:update";
                 public const string Delete = "customer:organization-membership:delete";
 
-                public static string[] AllPermissions { get; } = { Read, Create, Update, Delete };
+                public static string[] AllPermissions { get; } = [Read, Create, Update, Delete];
             }
 
             public static class Claims
@@ -46,14 +46,14 @@ namespace VirtoCommerce.CustomerModule.Core
             public const string Rejected = "Rejected";
             public const string Deleted = "Deleted";
 
-            public static string[] ManuallySelectableStatuses { get; } = { Invited, Approved, Rejected, Deleted };
+            public static string[] ManuallySelectableStatuses { get; } = [Invited, Approved, Rejected, Deleted];
 
-            public static string[] BlockingStatuses { get; } = { Invited, Rejected, Deleted };
+            public static string[] BlockingStatuses { get; } = [Invited, Rejected, Deleted];
 
             public static bool IsBlocking(string effectiveStatus) =>
                 !string.IsNullOrEmpty(effectiveStatus) && BlockingStatuses.Contains(effectiveStatus);
 
-            public static string[] ReinvitableStatuses { get; } = { Rejected, Deleted };
+            public static string[] ReinvitableStatuses { get; } = [Rejected, Deleted];
         }
 
         public static class Settings
@@ -67,7 +67,7 @@ namespace VirtoCommerce.CustomerModule.Core
                     ValueType = SettingValueType.ShortText,
                     IsDictionary = true,
                     DefaultValue = "New",
-                    AllowedValues = new object[] { "VIP", "Wholesaler" }
+                    AllowedValues = ["VIP", "Wholesaler"]
                 };
 
                 public static SettingDescriptor ExportImportPageSize { get; } = new SettingDescriptor
@@ -109,7 +109,8 @@ namespace VirtoCommerce.CustomerModule.Core
                     GroupName = "Customer|Roles",
                     ValueType = SettingValueType.ShortText,
                     IsDictionary = true,
-                    AllowedValues = [],
+                    IsPublic = true,
+                    AllowedValues = ["Organization maintainer", "Organization employee", "Purchasing agent", "Store administrator", "Store manager"],
                 };
 
                 #region Statuses
@@ -121,7 +122,7 @@ namespace VirtoCommerce.CustomerModule.Core
                     GroupName = "Customer|Statuses",
                     IsDictionary = true,
                     DefaultValue = "New",
-                    AllowedValues = new[] { "New", "Approved", "Rejected", "Deleted" }
+                    AllowedValues = ["New", "Approved", "Rejected", "Deleted"]
                 };
 
                 public static SettingDescriptor VendorStatuses { get; } = new SettingDescriptor
@@ -131,7 +132,7 @@ namespace VirtoCommerce.CustomerModule.Core
                     GroupName = "Customer|Statuses",
                     IsDictionary = true,
                     DefaultValue = "New",
-                    AllowedValues = new[] { "New", "Approved", "Rejected", "Deleted" }
+                    AllowedValues = ["New", "Approved", "Rejected", "Deleted"]
                 };
 
                 public static SettingDescriptor EmployeeStatuses { get; } = new SettingDescriptor
@@ -141,7 +142,7 @@ namespace VirtoCommerce.CustomerModule.Core
                     GroupName = "Customer|Statuses",
                     IsDictionary = true,
                     DefaultValue = "New",
-                    AllowedValues = new[] { "New", "Approved", "Rejected", "Deleted" }
+                    AllowedValues = ["New", "Approved", "Rejected", "Deleted"]
                 };
 
                 public static SettingDescriptor ContactStatuses { get; } = new SettingDescriptor
@@ -151,7 +152,7 @@ namespace VirtoCommerce.CustomerModule.Core
                     GroupName = "Customer|Statuses",
                     IsDictionary = true,
                     DefaultValue = "New",
-                    AllowedValues = new[] { "New", "Approved", "Rejected", "Deleted" }
+                    AllowedValues = ["New", "Approved", "Rejected", "Deleted"]
                 };
 
                 public static SettingDescriptor OrganizationMembershipStatuses { get; } = new SettingDescriptor
@@ -180,8 +181,8 @@ namespace VirtoCommerce.CustomerModule.Core
 
                 #endregion Statuses
 
-                public static IEnumerable<SettingDescriptor> AllSettings => new List<SettingDescriptor>
-                {
+                public static IEnumerable<SettingDescriptor> AllSettings =>
+                [
                     MemberGroups,
                     ExportImportPageSize,
                     MemberIndexationDate,
@@ -195,7 +196,7 @@ namespace VirtoCommerce.CustomerModule.Core
                     OrganizationMembershipStatuses,
                     OrganizationDefaultStatus,
                     ContactDefaultStatus
-                };
+                ];
             }
 
             public static IEnumerable<SettingDescriptor> StoreLevelSettings
@@ -204,6 +205,7 @@ namespace VirtoCommerce.CustomerModule.Core
                 {
                     yield return General.OrganizationDefaultStatus;
                     yield return General.ContactDefaultStatus;
+                    yield return General.MembershipRolesWhitelist;
                 }
             }
 

--- a/src/VirtoCommerce.CustomerModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CustomerModule.Core/ModuleConstants.cs
@@ -110,7 +110,7 @@ namespace VirtoCommerce.CustomerModule.Core
                     ValueType = SettingValueType.ShortText,
                     IsDictionary = true,
                     IsPublic = true,
-                    AllowedValues = ["Organization maintainer", "Organization employee", "Purchasing agent", "Store administrator", "Store manager"],
+                    AllowedValues = ["Organization employee", "Purchasing agent", "Organization maintainer"],
                 };
 
                 #region Statuses

--- a/src/VirtoCommerce.CustomerModule.Core/Services/CompanyMemberRoleWhitelistExtensions.cs
+++ b/src/VirtoCommerce.CustomerModule.Core/Services/CompanyMemberRoleWhitelistExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.Platform.Core.Security;
+
+namespace VirtoCommerce.CustomerModule.Core.Services;
+
+public static class CompanyMemberRoleWhitelistExtensions
+{
+    public static bool IsRoleAllowed(this IReadOnlyCollection<string> allowedRoleIds, Role role)
+    {
+        return allowedRoleIds.Contains(role.Id, StringComparer.OrdinalIgnoreCase) ||
+               allowedRoleIds.Contains(role.Name, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/VirtoCommerce.CustomerModule.Core/Services/CompanyMemberRoleWhitelistExtensions.cs
+++ b/src/VirtoCommerce.CustomerModule.Core/Services/CompanyMemberRoleWhitelistExtensions.cs
@@ -7,7 +7,7 @@ namespace VirtoCommerce.CustomerModule.Core.Services;
 
 public static class CompanyMemberRoleWhitelistExtensions
 {
-    public static bool IsRoleAllowed(this IReadOnlyCollection<string> allowedRoleIds, Role role)
+    public static bool IsRoleAllowed(this IList<string> allowedRoleIds, Role role)
     {
         return allowedRoleIds.Contains(role.Id, StringComparer.OrdinalIgnoreCase) ||
                allowedRoleIds.Contains(role.Name, StringComparer.OrdinalIgnoreCase);

--- a/src/VirtoCommerce.CustomerModule.Core/Services/ICompanyMemberRoleService.cs
+++ b/src/VirtoCommerce.CustomerModule.Core/Services/ICompanyMemberRoleService.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.CustomerModule.Core.Services;
+
+public interface ICompanyMemberRoleService
+{
+    Task<IReadOnlyCollection<string>> GetAllowedRoleIdsAsync(string storeId);
+}

--- a/src/VirtoCommerce.CustomerModule.Core/Services/ICompanyMemberRoleService.cs
+++ b/src/VirtoCommerce.CustomerModule.Core/Services/ICompanyMemberRoleService.cs
@@ -5,5 +5,5 @@ namespace VirtoCommerce.CustomerModule.Core.Services;
 
 public interface ICompanyMemberRoleService
 {
-    Task<IReadOnlyCollection<string>> GetAllowedRoleIdsAsync(string storeId);
+    Task<IList<string>> GetAllowedRoleIdsAsync(string storeId);
 }

--- a/src/VirtoCommerce.CustomerModule.Data/Services/CompanyMemberRoleService.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/CompanyMemberRoleService.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.StoreModule.Core.Model;
+
+namespace VirtoCommerce.CustomerModule.Data.Services;
+
+public class CompanyMemberRoleService : ICompanyMemberRoleService
+{
+    private readonly ISettingsManager _settingsManager;
+
+    public CompanyMemberRoleService(ISettingsManager settingsManager)
+    {
+        _settingsManager = settingsManager;
+    }
+
+    public virtual async Task<IReadOnlyCollection<string>> GetAllowedRoleIdsAsync(string storeId)
+    {
+        var descriptor = ModuleConstants.Settings.General.MembershipRolesWhitelist;
+
+        var setting = string.IsNullOrEmpty(storeId)
+            ? null
+            : await _settingsManager.GetObjectSettingAsync(descriptor.Name, nameof(Store), storeId);
+
+        var allowedValues = setting?.Id != null ? setting.AllowedValues : descriptor.AllowedValues;
+
+        return (allowedValues ?? [])
+            .Select(x => x?.ToString())
+            .Where(x => !x.IsNullOrEmpty())
+            .ToList();
+    }
+}

--- a/src/VirtoCommerce.CustomerModule.Data/Services/CompanyMemberRoleService.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/CompanyMemberRoleService.cs
@@ -18,7 +18,7 @@ public class CompanyMemberRoleService : ICompanyMemberRoleService
         _settingsManager = settingsManager;
     }
 
-    public virtual async Task<IReadOnlyCollection<string>> GetAllowedRoleIdsAsync(string storeId)
+    public virtual async Task<IList<string>> GetAllowedRoleIdsAsync(string storeId)
     {
         var descriptor = ModuleConstants.Settings.General.MembershipRolesWhitelist;
 

--- a/src/VirtoCommerce.CustomerModule.Data/Services/InviteCustomerService.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/InviteCustomerService.cs
@@ -28,7 +28,6 @@ public class InviteCustomerService : IInviteCustomerService
 {
     public virtual string InitialUserType => "Customer";
     public virtual string InitialContactStatus => "Invited";
-    public virtual string[] DefaultRoleIds => new[] { "org-employee", "purchasing-agent", "org-maintainer" };
 
     public virtual string InvitationUrlSuffix => "/confirm-invitation";
 
@@ -42,6 +41,7 @@ public class InviteCustomerService : IInviteCustomerService
     private readonly Func<RoleManager<Role>> _roleManagerFactory;
     private readonly IOrganizationMembershipService _organizationMembershipService;
     private readonly IOrganizationMembershipSearchService _organizationMembershipSearchService;
+    private readonly ICompanyMemberRoleService _companyMemberRoleService;
     private readonly ILogger<InviteCustomerService> _logger;
 
     public InviteCustomerService(
@@ -53,6 +53,7 @@ public class InviteCustomerService : IInviteCustomerService
         Func<RoleManager<Role>> roleManagerFactory,
         IOrganizationMembershipService organizationMembershipService,
         IOrganizationMembershipSearchService organizationMembershipSearchService,
+        ICompanyMemberRoleService companyMemberRoleService,
         ILogger<InviteCustomerService> logger)
     {
         _memberService = memberService;
@@ -63,6 +64,7 @@ public class InviteCustomerService : IInviteCustomerService
         _roleManagerFactory = roleManagerFactory;
         _organizationMembershipService = organizationMembershipService;
         _organizationMembershipSearchService = organizationMembershipSearchService;
+        _companyMemberRoleService = companyMemberRoleService;
         _logger = logger;
     }
 
@@ -94,7 +96,7 @@ public class InviteCustomerService : IInviteCustomerService
 
         var store = storeResult.Store;
 
-        var rolesResult = await GetRolesAsync(request.RoleIds);
+        var rolesResult = await GetRolesAsync(request.RoleIds, request.StoreId, request.OrganizationId);
         if (rolesResult.Errors.Count != 0)
         {
             result.Errors.AddRange(rolesResult.Errors);
@@ -269,12 +271,15 @@ public class InviteCustomerService : IInviteCustomerService
 
     public async Task<IList<CustomerRole>> GetInviteRolesAsync()
     {
+        var allowedRoleIds = await _companyMemberRoleService.GetAllowedRoleIdsAsync(null);
+
         using var roleManager = _roleManagerFactory();
+        var roles = await roleManager.Roles.ToListAsync();
 
-        var rolesQuery = roleManager.Roles.Where(x => DefaultRoleIds.Contains(x.Id));
-        var roles = await rolesQuery.ToListAsync();
-
-        var customerRoles = roles.Select(MapCustomerRole).ToList();
+        var customerRoles = roles
+            .Where(allowedRoleIds.IsRoleAllowed)
+            .Select(MapCustomerRole)
+            .ToList();
         return customerRoles;
     }
 
@@ -513,7 +518,7 @@ public class InviteCustomerService : IInviteCustomerService
         return result;
     }
 
-    protected virtual async Task<RolesResult> GetRolesAsync(string[] roleIds)
+    protected virtual async Task<RolesResult> GetRolesAsync(string[] roleIds, string storeId, string organizationId)
     {
         var result = new RolesResult();
 
@@ -522,17 +527,18 @@ public class InviteCustomerService : IInviteCustomerService
             return result;
         }
 
+        IReadOnlyCollection<string> allowedRoleIds = null;
+        if (!string.IsNullOrEmpty(organizationId))
+        {
+            allowedRoleIds = await _companyMemberRoleService.GetAllowedRoleIdsAsync(storeId);
+        }
+
         using var roleManager = _roleManagerFactory();
 
         foreach (var roleId in roleIds)
         {
             var role = await roleManager.FindByIdAsync(roleId) ?? await roleManager.FindByNameAsync(roleId);
-            if (role != null)
-            {
-
-                result.Roles.Add(role);
-            }
-            else
+            if (role == null)
             {
                 result.Errors.Add(new InviteCustomerError
                 {
@@ -544,6 +550,21 @@ public class InviteCustomerService : IInviteCustomerService
 
                 return result;
             }
+
+            if (allowedRoleIds != null && !allowedRoleIds.IsRoleAllowed(role))
+            {
+                result.Errors.Add(new InviteCustomerError
+                {
+                    Code = "RoleNotAllowed",
+                    Description = $"Role '{roleId}' is not allowed for company members of this store",
+                    Parameter = roleId,
+                    Email = "Common",
+                });
+
+                return result;
+            }
+
+            result.Roles.Add(role);
         }
 
         return result;

--- a/src/VirtoCommerce.CustomerModule.Data/Services/InviteCustomerService.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/Services/InviteCustomerService.cs
@@ -527,7 +527,7 @@ public class InviteCustomerService : IInviteCustomerService
             return result;
         }
 
-        IReadOnlyCollection<string> allowedRoleIds = null;
+        IList<string> allowedRoleIds = null;
         if (!string.IsNullOrEmpty(organizationId))
         {
             allowedRoleIds = await _companyMemberRoleService.GetAllowedRoleIdsAsync(storeId);

--- a/src/VirtoCommerce.CustomerModule.Web/Module.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Module.cs
@@ -156,7 +156,7 @@ namespace VirtoCommerce.CustomerModule.Web
             AbstractTypeFactory<MemberEntity>.RegisterType<EmployeeEntity>();
 
             var settingsRegistrar = appBuilder.ApplicationServices.GetRequiredService<ISettingsRegistrar>();
-            settingsRegistrar.RegisterSettings(ModuleConstants.Settings.AllSettings, ModuleInfo.Id);
+            settingsRegistrar.RegisterSettings(ModuleConstants.Settings.AllModuleSettings, ModuleInfo.Id);
             settingsRegistrar.RegisterSettingsForType(ModuleConstants.Settings.StoreLevelSettings, nameof(Store));
 
             var dynamicPropertyRegistrar = appBuilder.ApplicationServices.GetRequiredService<IDynamicPropertyRegistrar>();

--- a/src/VirtoCommerce.CustomerModule.Web/Module.cs
+++ b/src/VirtoCommerce.CustomerModule.Web/Module.cs
@@ -137,6 +137,7 @@ namespace VirtoCommerce.CustomerModule.Web
             serviceCollection.AddTransient<ICustomerPreferenceService, CustomerPreferenceService>();
 
             serviceCollection.AddTransient<IInviteCustomerService, InviteCustomerService>();
+            serviceCollection.AddTransient<ICompanyMemberRoleService, CompanyMemberRoleService>();
             serviceCollection.AddTransient<IAddressService, AddressService>();
             serviceCollection.AddTransient<IAddressSearchService, AddressSearchService>();
         }

--- a/src/VirtoCommerce.CustomerModule.Web/Scripts/blades/organization-membership-detail.js
+++ b/src/VirtoCommerce.CustomerModule.Web/Scripts/blades/organization-membership-detail.js
@@ -69,6 +69,7 @@ angular.module('virtoCommerce.customerModule')
 
             var rolesPicker = rolesPickerService.create({
                 whitelistSettingId: 'Customer.MembershipRolesWhitelist',
+                storeId: blade.storeId,
                 getSelectedRoles: function () { return blade.currentEntity.roles; },
                 onAvailableRolesChanged: function (list) { blade.availableRoles = list; }
             });

--- a/src/VirtoCommerce.CustomerModule.Web/Scripts/blades/organization-memberships-list.js
+++ b/src/VirtoCommerce.CustomerModule.Web/Scripts/blades/organization-memberships-list.js
@@ -38,6 +38,7 @@ angular.module('virtoCommerce.customerModule')
                 var newBlade = {
                     id: 'organizationMembershipDetail',
                     userId: blade.userId,
+                    storeId: blade.storeId,
                     currentEntity: angular.copy(item),
                     isGlobal: item.organizationId === null || item.organizationId === undefined,
                     title: item.organizationId ? item.organizationName : 'customer.blades.organization-membership-detail.title-global',
@@ -62,6 +63,7 @@ angular.module('virtoCommerce.customerModule')
                         var newBlade = {
                             id: 'organizationMembershipDetail',
                             userId: blade.userId,
+                            storeId: blade.storeId,
                             currentEntity: { userId: blade.userId, roles: [], isLocked: false },
                             isNew: true,
                             title: 'customer.blades.organization-membership-detail.title-new',

--- a/src/VirtoCommerce.CustomerModule.Web/Scripts/services/rolesPickerService.js
+++ b/src/VirtoCommerce.CustomerModule.Web/Scripts/services/rolesPickerService.js
@@ -1,13 +1,29 @@
 angular.module('virtoCommerce.customerModule')
-    .factory('virtoCommerce.customerModule.rolesPickerService', ['platformWebApp.roles', 'platformWebApp.settings',
-        function (roles, settings) {
+    .factory('virtoCommerce.customerModule.rolesPickerService', ['platformWebApp.roles', 'platformWebApp.settings', 'platformWebApp.settingsV2',
+        function (roles, settings, settingsV2) {
             return {
                 create: function (options) {
-                    var whitelist = options.whitelistSettingId
-                        ? (settings.getValues({ id: options.whitelistSettingId }) || [])
-                        : [];
+                    var whitelist = [];
+
+                    if (options.whitelistSettingId) {
+                        var globalWhitelist = settings.getValues({ id: options.whitelistSettingId }) || [];
+                        whitelist = globalWhitelist;
+                        globalWhitelist.$promise.then(reapplyWhitelist);
+
+                        if (options.storeId) {
+                            settingsV2.getTenantValues({ tenantType: 'Store', tenantId: options.storeId }).$promise.then(function (values) {
+                                var storeValues = (values && values[options.whitelistSettingId]) || [];
+                                if (storeValues.length) {
+                                    whitelist = storeValues;
+                                    reapplyWhitelist();
+                                }
+                            });
+                        }
+                    }
+
                     var requestToken = 0;
                     var lastFetchedRoles = [];
+                    var lastUnfilteredRoles = [];
 
                     function isRoleAvailable(role) {
                         var selected = (options.getSelectedRoles() || []).map(function (r) {
@@ -23,6 +39,26 @@ angular.module('virtoCommerce.customerModule')
                         options.onAvailableRolesChanged(lastFetchedRoles.filter(isRoleAvailable));
                     }
 
+                    function filterByWhitelist(allRoles) {
+                        if (!whitelist.length) {
+                            return allRoles;
+                        }
+
+                        var whitelistLower = whitelist.map(function (value) {
+                            return value.toLowerCase();
+                        });
+
+                        return allRoles.filter(function (r) {
+                            return whitelistLower.indexOf(r.name.toLowerCase()) !== -1 ||
+                                whitelistLower.indexOf((r.id || '').toLowerCase()) !== -1;
+                        });
+                    }
+
+                    function reapplyWhitelist() {
+                        lastFetchedRoles = filterByWhitelist(lastUnfilteredRoles);
+                        updateAvailableRoles();
+                    }
+
                     return {
                         refresh: function (keyword) {
                             requestToken++;
@@ -33,19 +69,8 @@ angular.module('virtoCommerce.customerModule')
                                     return;
                                 }
 
-                                var allRoles = data.results || [];
-
-                                if (whitelist.length) {
-                                    var whitelistLower = whitelist.map(function (value) {
-                                        return value.toLowerCase();
-                                    });
-
-                                    allRoles = allRoles.filter(function (r) {
-                                        return whitelistLower.indexOf(r.name.toLowerCase()) !== -1;
-                                    });
-                                }
-
-                                lastFetchedRoles = allRoles;
+                                lastUnfilteredRoles = data.results || [];
+                                lastFetchedRoles = filterByWhitelist(lastUnfilteredRoles);
                                 updateAvailableRoles();
                             });
                         },

--- a/src/VirtoCommerce.CustomerModule.Web/Scripts/widgets/organizationMembershipsWidget.js
+++ b/src/VirtoCommerce.CustomerModule.Web/Scripts/widgets/organizationMembershipsWidget.js
@@ -30,9 +30,11 @@ angular.module('virtoCommerce.customerModule')
                     return;
                 }
                 var userId = blade.currentEntity.securityAccounts[0].id;
+                var storeId = blade.currentEntity.securityAccounts[0].storeId;
                 var newBlade = {
                     id: 'organizationMembershipsList',
                     userId: userId,
+                    storeId: storeId,
                     contact: blade.currentEntity,
                     title: blade.title,
                     subtitle: 'customer.widgets.organization-memberships.blade-subtitle',

--- a/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleServiceTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleServiceTests.cs
@@ -52,7 +52,8 @@ public class CompanyMemberRoleServiceTests
         // Assert
         Assert.Equal(descriptorDefaults.Length, result.Count);
         Assert.Contains("Organization maintainer", result);
-        Assert.Contains("Store manager", result);
+        Assert.Contains("Organization employee", result);
+        Assert.Contains("Purchasing agent", result);
     }
 
     [Fact]

--- a/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleServiceTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleServiceTests.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.CustomerModule.Core;
+using VirtoCommerce.CustomerModule.Data.Services;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.StoreModule.Core.Model;
+using Xunit;
+
+namespace VirtoCommerce.CustomerModule.Tests;
+
+public class CompanyMemberRoleServiceTests
+{
+    private readonly Mock<ISettingsManager> _settingsManagerMock = new();
+
+    [Fact]
+    public async Task GetAllowedRoleIdsAsync_StoreOverrideConfigured_ReturnsStoreValues()
+    {
+        // Arrange
+        var descriptorName = ModuleConstants.Settings.General.MembershipRolesWhitelist.Name;
+
+        _settingsManagerMock
+            .Setup(x => x.GetObjectSettingAsync(descriptorName, nameof(Store), "store-1"))
+            .ReturnsAsync(new ObjectSettingEntry { Id = "store-setting-1", AllowedValues = new object[] { "org-maintainer" } });
+
+        var service = new CompanyMemberRoleService(_settingsManagerMock.Object);
+
+        // Act
+        var result = await service.GetAllowedRoleIdsAsync("store-1");
+
+        // Assert
+        Assert.Equal(["org-maintainer"], result);
+    }
+
+    [Fact]
+    public async Task GetAllowedRoleIdsAsync_NoStoreOverride_FallsBackToDescriptorDefaults()
+    {
+        // Arrange — no DB row for this store (Id is null on the returned entry), so it must fall
+        // straight to the code-defined default. There is no separate "global override" tier — matches
+        // how the rest of the platform (e.g. GetStoreQueryHandler) resolves store-level settings.
+        var descriptorName = ModuleConstants.Settings.General.MembershipRolesWhitelist.Name;
+        var descriptorDefaults = ModuleConstants.Settings.General.MembershipRolesWhitelist.AllowedValues;
+
+        _settingsManagerMock
+            .Setup(x => x.GetObjectSettingAsync(descriptorName, nameof(Store), "store-1"))
+            .ReturnsAsync(new ObjectSettingEntry { Id = null, AllowedValues = descriptorDefaults });
+
+        var service = new CompanyMemberRoleService(_settingsManagerMock.Object);
+
+        // Act
+        var result = await service.GetAllowedRoleIdsAsync("store-1");
+
+        // Assert
+        Assert.Equal(descriptorDefaults.Length, result.Count);
+        Assert.Contains("Organization maintainer", result);
+        Assert.Contains("Store manager", result);
+    }
+
+    [Fact]
+    public async Task GetAllowedRoleIdsAsync_NoStoreId_FallsBackToDescriptorDefaults()
+    {
+        // Arrange
+        var service = new CompanyMemberRoleService(_settingsManagerMock.Object);
+
+        // Act
+        var result = await service.GetAllowedRoleIdsAsync(null);
+
+        // Assert
+        Assert.Equal(ModuleConstants.Settings.General.MembershipRolesWhitelist.AllowedValues.Length, result.Count);
+        _settingsManagerMock.Verify(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+}

--- a/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleWhitelistExtensionsTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleWhitelistExtensionsTests.cs
@@ -1,0 +1,40 @@
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Core.Security;
+using Xunit;
+
+namespace VirtoCommerce.CustomerModule.Tests;
+
+public class CompanyMemberRoleWhitelistExtensionsTests
+{
+    [Fact]
+    public void IsRoleAllowed_MatchesById()
+    {
+        var role = new Role { Id = "org-maintainer", Name = "Organization maintainer" };
+
+        Assert.True(new[] { "org-maintainer" }.IsRoleAllowed(role));
+    }
+
+    [Fact]
+    public void IsRoleAllowed_MatchesByName()
+    {
+        var role = new Role { Id = "5f3d9c1e-1234-4a5b-9abc-1234567890ab", Name = "Organization maintainer" };
+
+        Assert.True(new[] { "Organization maintainer" }.IsRoleAllowed(role));
+    }
+
+    [Fact]
+    public void IsRoleAllowed_MatchIsCaseInsensitive()
+    {
+        var role = new Role { Id = "org-maintainer", Name = "Organization maintainer" };
+
+        Assert.True(new[] { "ORGANIZATION MAINTAINER" }.IsRoleAllowed(role));
+    }
+
+    [Fact]
+    public void IsRoleAllowed_NoIdOrNameMatch_ReturnsFalse()
+    {
+        var role = new Role { Id = "org-maintainer", Name = "Organization maintainer" };
+
+        Assert.False(new[] { "purchasing-agent" }.IsRoleAllowed(role));
+    }
+}

--- a/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleWhitelistExtensionsTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/CompanyMemberRoleWhitelistExtensionsTests.cs
@@ -6,12 +6,17 @@ namespace VirtoCommerce.CustomerModule.Tests;
 
 public class CompanyMemberRoleWhitelistExtensionsTests
 {
+    private static readonly string[] _orgMaintainerId = ["org-maintainer"];
+    private static readonly string[] _organizationMaintainerName = ["Organization maintainer"];
+    private static readonly string[] _organizationMaintainerNameUpperCase = ["ORGANIZATION MAINTAINER"];
+    private static readonly string[] _purchasingAgentId = ["purchasing-agent"];
+
     [Fact]
     public void IsRoleAllowed_MatchesById()
     {
         var role = new Role { Id = "org-maintainer", Name = "Organization maintainer" };
 
-        Assert.True(new[] { "org-maintainer" }.IsRoleAllowed(role));
+        Assert.True(_orgMaintainerId.IsRoleAllowed(role));
     }
 
     [Fact]
@@ -19,7 +24,7 @@ public class CompanyMemberRoleWhitelistExtensionsTests
     {
         var role = new Role { Id = "5f3d9c1e-1234-4a5b-9abc-1234567890ab", Name = "Organization maintainer" };
 
-        Assert.True(new[] { "Organization maintainer" }.IsRoleAllowed(role));
+        Assert.True(_organizationMaintainerName.IsRoleAllowed(role));
     }
 
     [Fact]
@@ -27,7 +32,7 @@ public class CompanyMemberRoleWhitelistExtensionsTests
     {
         var role = new Role { Id = "org-maintainer", Name = "Organization maintainer" };
 
-        Assert.True(new[] { "ORGANIZATION MAINTAINER" }.IsRoleAllowed(role));
+        Assert.True(_organizationMaintainerNameUpperCase.IsRoleAllowed(role));
     }
 
     [Fact]
@@ -35,6 +40,6 @@ public class CompanyMemberRoleWhitelistExtensionsTests
     {
         var role = new Role { Id = "org-maintainer", Name = "Organization maintainer" };
 
-        Assert.False(new[] { "purchasing-agent" }.IsRoleAllowed(role));
+        Assert.False(_purchasingAgentId.IsRoleAllowed(role));
     }
 }

--- a/tests/VirtoCommerce.CustomerModule.Tests/InviteCustomerServiceTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/InviteCustomerServiceTests.cs
@@ -30,6 +30,7 @@ public class InviteCustomerServiceTests
     private readonly Mock<RoleManager<Role>> _roleManagerMock;
     private readonly Mock<IOrganizationMembershipService> _membershipServiceMock = new();
     private readonly Mock<IOrganizationMembershipSearchService> _membershipSearchServiceMock = new();
+    private readonly Mock<ICompanyMemberRoleService> _companyMemberRoleServiceMock = new();
     private readonly Mock<ILogger<InviteCustomerService>> _loggerMock = new();
 
     public InviteCustomerServiceTests()
@@ -300,6 +301,92 @@ public class InviteCustomerServiceTests
                 members.Length == 1 &&
                 members[0].Id == "contact-1" &&
                 ((Contact)members[0]).Organizations.SequenceEqual(new[] { "org-1", "org-2" }))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InviteCustomerAsyc_OrganizationInviteWithDisallowedRole_ReturnsRoleNotAllowedError()
+    {
+        // Arrange
+        var store = new Store { Id = "store-1", Url = "https://store.test", Email = "store@test.com" };
+        _storeServiceMock.Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync([store]);
+
+        _roleManagerMock.Setup(x => x.FindByIdAsync("not-allowed-role"))
+            .ReturnsAsync(new Role { Id = "not-allowed-role", Name = "not-allowed-role" });
+
+        _companyMemberRoleServiceMock.Setup(x => x.GetAllowedRoleIdsAsync("store-1"))
+            .ReturnsAsync(["org-maintainer", "org-employee"]);
+
+        _userManagerMock.Setup(x => x.FindByEmailAsync("new@test.com")).ReturnsAsync((ApplicationUser)null);
+        _userManagerMock.Setup(x => x.FindByNameAsync("new@test.com")).ReturnsAsync((ApplicationUser)null);
+
+        var service = BuildTestableService();
+
+        var request = new InviteCustomerRequest
+        {
+            StoreId = "store-1",
+            OrganizationId = "org-1",
+            Emails = ["new@test.com"],
+            RoleIds = ["not-allowed-role"],
+        };
+
+        // Act
+        var result = await service.InviteCustomerAsyc(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Errors, e => e.Code == "RoleNotAllowed" && e.Parameter == "not-allowed-role");
+
+        _membershipServiceMock.Verify(x => x.SaveChangesAsync(It.IsAny<IList<OrganizationMembership>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InviteCustomerAsyc_OrganizationInviteWithAllowedRole_Succeeds()
+    {
+        // Arrange
+        var store = new Store { Id = "store-1", Url = "https://store.test", Email = "store@test.com" };
+        _storeServiceMock.Setup(x => x.GetAsync(It.IsAny<IList<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .ReturnsAsync([store]);
+
+        _roleManagerMock.Setup(x => x.FindByIdAsync("org-maintainer"))
+            .ReturnsAsync(new Role { Id = "org-maintainer", Name = "org-maintainer" });
+
+        _companyMemberRoleServiceMock.Setup(x => x.GetAllowedRoleIdsAsync("store-1"))
+            .ReturnsAsync(["org-maintainer", "org-employee"]);
+
+        _notificationSearchServiceMock
+            .Setup(x => x.SearchNotificationsAsync(It.IsAny<NotificationSearchCriteria>()))
+            .ReturnsAsync(new NotificationSearchResult
+            {
+                Results = [new OrganizationInviteNewUserEmailNotification()],
+                TotalCount = 1,
+            });
+
+        _userManagerMock.Setup(x => x.FindByEmailAsync("new@test.com")).ReturnsAsync((ApplicationUser)null);
+        _userManagerMock.Setup(x => x.FindByNameAsync("new@test.com")).ReturnsAsync((ApplicationUser)null);
+        _userManagerMock.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+        _userManagerMock.Setup(x => x.GeneratePasswordResetTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync("token123");
+
+        var service = BuildTestableService();
+
+        var request = new InviteCustomerRequest
+        {
+            StoreId = "store-1",
+            OrganizationId = "org-1",
+            Emails = ["new@test.com"],
+            RoleIds = ["org-maintainer"],
+        };
+
+        // Act
+        var result = await service.InviteCustomerAsyc(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result.Succeeded);
+
+        _membershipServiceMock.Verify(
+            x => x.SaveChangesAsync(It.Is<IList<OrganizationMembership>>(list =>
+                list.Count == 1 && list[0].Roles.Any(r => r.RoleId == "org-maintainer"))),
             Times.Once);
     }
 
@@ -614,6 +701,7 @@ public class InviteCustomerServiceTests
             () => _roleManagerMock.Object,
             _membershipServiceMock.Object,
             _membershipSearchServiceMock.Object,
+            _companyMemberRoleServiceMock.Object,
             _loggerMock.Object);
 
     private sealed class TestableInviteCustomerService(
@@ -625,9 +713,11 @@ public class InviteCustomerServiceTests
         Func<RoleManager<Role>> roleManagerFactory,
         IOrganizationMembershipService organizationMembershipService,
         IOrganizationMembershipSearchService organizationMembershipSearchService,
+        ICompanyMemberRoleService companyMemberRoleService,
         ILogger<InviteCustomerService> logger)
         : InviteCustomerService(memberService, storeService, notificationSearchService, notificationSender,
-            userManagerFactory, roleManagerFactory, organizationMembershipService, organizationMembershipSearchService, logger)
+            userManagerFactory, roleManagerFactory, organizationMembershipService, organizationMembershipSearchService,
+            companyMemberRoleService, logger)
     {
         public ApplicationUser InvokeCreateUser(
             InviteCustomerRequest request, Contact contact, string email, List<Role> roles)


### PR DESCRIPTION
## Description
Introduces a store-scoped whitelist setting for company member roles (`Customer.MembershipRolesWhitelist`), replacing the previously hardcoded 3-role list used across invite and role-assignment flows.

## What was added
- **New setting**: `Customer.MembershipRolesWhitelist` (dictionary, public, store-scoped) with default values `Organization employee`, `Purchasing agent`, `Organization maintainer` — same defaults the app used before this feature existed.
- **New abstraction**: `ICompanyMemberRoleService` / `CompanyMemberRoleService` resolves the effective allowed role list for a given store, falling back to the setting's registered defaults when no store-level override is configured.
- **New extension**: `CompanyMemberRoleWhitelistExtensions.IsRoleAllowed(this IList<string>, Role)` — case-insensitive match by role Id or Name, shared by all enforcement points.
- **`InviteCustomerService`**: invite role validation and `GetInviteRolesAsync()` now filter through the store's whitelist; invalid/disallowed roles are rejected with a dedicated `RoleNotAllowed` error.
- **Backoffice**: `rolesPickerService.js` resolves the whitelist per store (falling back to the global default) so the role picker widget only offers allowed roles when assigning organization membership roles.

## Breaking changes
- `InviteCustomerService.DefaultRoleIds` (`public virtual string[]`) has been **removed** — role defaults are now setting-driven, not a compile-time constant. No internal references remained.
- `InviteCustomerService.GetRolesAsync(string[] roleIds)` → `GetRolesAsync(string[] roleIds, string storeId, string organizationId)` (`protected virtual`) — signature changed to thread through the store scope needed for whitelist validation. Breaks any external override of this method.
- `ModuleConstants.Settings.AllSettings` renamed to `ModuleConstants.Settings.AllModuleSettings` (fixes a Sonar "property shadows outer member" finding against the also-renamed-back `General.AllSettings`). Only internal consumer (`Module.cs`, both main and sample module) updated; breaks any external code referencing the old name directly.

## Tests
- `CompanyMemberRoleServiceTests`, `CompanyMemberRoleWhitelistExtensionsTests` (new)
- `InviteCustomerServiceTests` extended to cover whitelist enforcement
- Full suite: 184/184 passing

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5450
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1023.0-alpha.1009-vcst-5450.zip