### PR TITLE
VCST-5317: Hide locked organizations from the header org switcher

### DIFF
--- a/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
+++ b/src/VirtoCommerce.CustomerModule.Data/OpenIddict/OrganizationIdRequestValidator.cs
@@ -110,6 +110,12 @@ public class OrganizationIdRequestValidator(
                 context.Request.SetParameter(Parameters.OrganizationId, fallbackOrganizationId);
                 return null;
             }
+
+            if (isLocked)
+            {
+                context.Request.SetParameter(Parameters.OrganizationId, null);
+                return null;
+            }
         }
 
         return isLocked ? ErrorDescriber.UserIsLockedInOrganization(organizationId) : statusError;

--- a/tests/VirtoCommerce.CustomerModule.Tests/OrganizationIdRequestValidatorTests.cs
+++ b/tests/VirtoCommerce.CustomerModule.Tests/OrganizationIdRequestValidatorTests.cs
@@ -207,6 +207,25 @@ public class OrganizationIdRequestValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_PasswordGrantAllOrganizationsLocked_ClearsOrgIdAndReturnsEmpty()
+    {
+        //Arrange — the user's only organization is locked, so there's no other org to fall back to.
+        var user = new ApplicationUser { Id = UserId, MemberId = MemberId };
+        _memberServiceMock.Setup(s => s.GetByIdAsync(MemberId, null, null))
+            .ReturnsAsync(new Contact { Id = MemberId, Organizations = [OrgId] });
+        SetupMembership(new OrganizationMembership { OrganizationId = OrgId, IsLocked = true, LockoutEnd = null });
+
+        var context = BuildContext(OrgId, grantType: OpenIddictConstants.GrantTypes.Password, user: user);
+
+        //Act
+        var result = await GetValidator().ValidateAsync(context);
+
+        //Assert
+        Assert.Empty(result);
+        Assert.Null(context.Request.GetParameter(Parameters.OrganizationId)?.ToString());
+    }
+
+    [Fact]
     public async Task ValidateAsync_ActiveMembership_ReturnsEmpty()
     {
         //Arrange


### PR DESCRIPTION
## Description

VCST-5317 follow-up: if all of a user's organizations become locked, the stale `organization_id` the storefront resends on every password sign-in (`useAuth.ts`) used to block login entirely with `user_is_locked_in_organization`. `OrganizationIdRequestValidator.ValidateOrganizationAccessAsync` now drops the stale `organization_id` and lets the password grant succeed without one when there's no other organization to fall back to — mirroring how `HandleUnavailableOrganizationAsync` already treats an unresolvable `organization_id` for a password grant. Scoped to the lock case only: a rejected/invited/removed membership still blocks sign-in when there's no fallback, since that reflects a deliberate access decision, not an administrative lock.

Added a unit test covering the all-organizations-locked password-grant case.

## References
### QA-test:
[vc-testing-module#192](https://github.com/VirtoCommerce/vc-testing-module/pull/192)
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5317
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Customer_3.1024.0-pr-316-1ac3.zip